### PR TITLE
Change image picker intent to ACTION_OPEN_DOCUMENT and save image locally

### DIFF
--- a/app/src/main/java/org/fedorahosted/freeotp/add/AddActivity.java
+++ b/app/src/main/java/org/fedorahosted/freeotp/add/AddActivity.java
@@ -20,6 +20,9 @@
 
 package org.fedorahosted.freeotp.add;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Locale;
@@ -29,8 +32,10 @@ import org.fedorahosted.freeotp.TokenPersistence;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Bundle;
+import android.provider.MediaStore;
 import android.text.TextWatcher;
 import android.view.View;
 import android.widget.CompoundButton;
@@ -147,11 +152,25 @@ public class AddActivity extends Activity implements View.OnClickListener, Compo
         super.onActivityResult(requestCode, resultCode, data);
 
         if (resultCode == RESULT_OK) {
-            mImageURL = data.getData();
-            Picasso.with(this)
-                    .load(mImageURL)
-                    .placeholder(R.drawable.logo)
-                    .into(mImage);
+            Uri imageUri = data.getData();
+            try {
+                int i = 0;
+                File f;
+                String filename;
+                do {
+                    filename = getApplicationInfo().dataDir + "/img_" + i++ + ".png";
+                    f = new File(filename);
+                } while (f.exists());
+                Bitmap bitmap = MediaStore.Images.Media.getBitmap(this.getContentResolver(), imageUri);
+                FileOutputStream out = new FileOutputStream(filename);
+                bitmap.compress(Bitmap.CompressFormat.PNG, 100, out);
+                Picasso.with(this)
+                        .load(Uri.fromFile(f))
+                        .placeholder(R.drawable.logo)
+                        .into(mImage);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
         }
     }
 }

--- a/app/src/main/java/org/fedorahosted/freeotp/edit/EditActivity.java
+++ b/app/src/main/java/org/fedorahosted/freeotp/edit/EditActivity.java
@@ -138,7 +138,7 @@ public class EditActivity extends BaseActivity implements TextWatcher, View.OnCl
     public void onClick(View v) {
         switch (v.getId()) {
             case R.id.image:
-                startActivityForResult(new Intent(Intent.ACTION_PICK,
+                startActivityForResult(new Intent(Intent.ACTION_OPEN_DOCUMENT,
                         android.provider.MediaStore.Images.Media.EXTERNAL_CONTENT_URI), 0);
                 break;
 

--- a/app/src/main/java/org/fedorahosted/freeotp/edit/EditActivity.java
+++ b/app/src/main/java/org/fedorahosted/freeotp/edit/EditActivity.java
@@ -25,8 +25,10 @@ import org.fedorahosted.freeotp.Token;
 import org.fedorahosted.freeotp.TokenPersistence;
 
 import android.content.Intent;
+import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Bundle;
+import android.provider.MediaStore;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.view.View;
@@ -35,6 +37,10 @@ import android.widget.EditText;
 import android.widget.ImageButton;
 
 import com.squareup.picasso.Picasso;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 
 public class EditActivity extends BaseActivity implements TextWatcher, View.OnClickListener {
     private EditText           mIssuer;
@@ -112,8 +118,24 @@ public class EditActivity extends BaseActivity implements TextWatcher, View.OnCl
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
 
-        if (resultCode == RESULT_OK)
-            showImage(data.getData());
+        if (resultCode == RESULT_OK) {
+            Uri imageUri = data.getData();
+            try {
+                int i = 0;
+                File f;
+                String filename;
+                do {
+                    filename = getApplicationInfo().dataDir + "/img_" + i + ".png";
+                    f = new File(filename);
+                } while (f.exists());
+                Bitmap bitmap = MediaStore.Images.Media.getBitmap(this.getContentResolver(), imageUri);
+                FileOutputStream out = new FileOutputStream(filename);
+                bitmap.compress(Bitmap.CompressFormat.PNG, 100, out);
+                showImage(Uri.fromFile(f));
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
     }
 
     @Override

--- a/app/src/main/java/org/fedorahosted/freeotp/edit/EditActivity.java
+++ b/app/src/main/java/org/fedorahosted/freeotp/edit/EditActivity.java
@@ -125,7 +125,7 @@ public class EditActivity extends BaseActivity implements TextWatcher, View.OnCl
                 File f;
                 String filename;
                 do {
-                    filename = getApplicationInfo().dataDir + "/img_" + i + ".png";
+                    filename = getApplicationInfo().dataDir + "/img_" + i++ + ".png";
                     f = new File(filename);
                 } while (f.exists());
                 Bitmap bitmap = MediaStore.Images.Media.getBitmap(this.getContentResolver(), imageUri);


### PR DESCRIPTION
I'm suggesting this patch to fix the issue #51 regarding non persistent custom icons.

According to https://developer.android.com/guide/topics/providers/document-provider.html "Use ACTION_OPEN_DOCUMENT if you want your app to have long term, persistent access to documents owned by a document provider. An example would be a photo-editing app that lets users edit images stored in a document provider."

I've tested this successfully with my Google Nexus 7 Tablet and Android 6.0.1.