### PR TITLE
Remove unnecessary Android permissions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,8 +37,6 @@
         android:anyDensity="true" />
 
     <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-feature android:name="android.hardware.camera" android:required="false" />
     <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
 


### PR DESCRIPTION
The INTERNET and READ_EXTERNAL_STORAGE permissions seem to be unused and should be removed.

(Fixes #75, same patch ported to current repo)