### PR TITLE
implement support for SteamGuard OTPs

### DIFF
--- a/app/src/main/java/org/fedorahosted/freeotp/Token.java
+++ b/app/src/main/java/org/fedorahosted/freeotp/Token.java
@@ -42,6 +42,11 @@ public class Token {
         HOTP, TOTP
     }
 
+    private static char[] STEAMCHARS = new char[] {
+            '2', '3', '4', '5', '6', '7', '8', '9', 'B', 'C',
+            'D', 'F', 'G', 'H', 'J', 'K', 'M', 'N', 'P', 'Q',
+            'R', 'T', 'V', 'W', 'X', 'Y'};
+
     private String issuerInt;
     private String issuerExt;
     private String issuerAlt;
@@ -97,7 +102,7 @@ public class Token {
             if (d == null)
                 d = "6";
             digits = Integer.parseInt(d);
-            if (digits != 6 && digits != 8)
+            if (!issuerExt.equals("Steam") && digits != 6 && digits != 8)
                 throw new TokenUriInvalidException();
         } catch (NumberFormatException e) {
             throw new TokenUriInvalidException();
@@ -165,12 +170,21 @@ public class Token {
             binary |= (digest[off + 1] & 0xff) << 0x10;
             binary |= (digest[off + 2] & 0xff) << 0x08;
             binary |= (digest[off + 3] & 0xff);
-            binary = binary % div;
 
-            // Zero pad
-            String hotp = Integer.toString(binary);
-            while (hotp.length() != digits)
-                hotp = "0" + hotp;
+            String hotp = "";
+            if (issuerExt.equals("Steam")) {
+                for (int i = 0; i < digits; i++) {
+                    hotp += STEAMCHARS[binary % STEAMCHARS.length];
+                    binary /= STEAMCHARS.length;
+                }
+            } else {
+                binary = binary % div;
+
+                // Zero pad
+                hotp = Integer.toString(binary);
+                while (hotp.length() != digits)
+                    hotp = "0" + hotp;
+            }
 
             return hotp;
         } catch (InvalidKeyException e) {


### PR DESCRIPTION
This implements support for Steam's unusual OTP output format (5 characters, custom character set).

Purposefully ignores the "digits" argument in the URI if the issuerExt is "Steam".