### PR TITLE
fixes freeotp/freeotp-android#98

### DIFF
--- a/app/src/main/java/org/fedorahosted/freeotp/Token.java
+++ b/app/src/main/java/org/fedorahosted/freeotp/Token.java
@@ -105,9 +105,11 @@ public class Token {
 
         try {
             String p = uri.getQueryParameter("period");
-            if (p == null)
+            if (p == null) {
                 p = "30";
+            }
             period = Integer.parseInt(p);
+            period = (period > 0) ? period : 30; // correct the divide by zero opportunity
         } catch (NumberFormatException e) {
             throw new TokenUriInvalidException();
         }

--- a/app/src/test/java/org/fedorahosted/freeotp/TokenCodeTest.java
+++ b/app/src/test/java/org/fedorahosted/freeotp/TokenCodeTest.java
@@ -1,16 +1,12 @@
 package org.fedorahosted.freeotp;
 
-import android.net.Uri;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TokenCodeTest {
@@ -20,10 +16,10 @@ public class TokenCodeTest {
     @Before
     public void setUp() throws Exception {
         // otpauth://totp/FreeOTP:joe@google.com?secret=JBSWY3DPEHPK3PXP&issuer=FreeOTP
-        totpToken = mockToken("totp", null);
+        totpToken = TokenTestUtils.mockToken("totp", null);
 
         // otpauth://hotp/FreeOTP:joe@google.com?secret=JBSWY3DPEHPK3PXP&issuer=FreeOTP
-        hotpToken = mockToken("hotp", "0");
+        hotpToken = TokenTestUtils.mockToken("hotp", "0");
     }
 
     @Test
@@ -54,31 +50,4 @@ public class TokenCodeTest {
         assertEquals("282760", code);
     }
 
-    // Who tests the test utils?
-    public static Token mockToken(String authority, String counter){
-       return mockToken(authority, counter, "FreeOTP:joe@google.com");
-    }
-
-    public static Token mockToken(String authority, String counter, String id) {
-        // https://github.com/google/google-authenticator/wiki/Key-Uri-Format
-        Uri mMockUri = Mockito.mock(Uri.class);
-
-        when(mMockUri.getScheme()).thenReturn("otpauth");
-        when(mMockUri.getAuthority()).thenReturn(authority);
-        when(mMockUri.getPath()).thenReturn(id);
-        when(mMockUri.getQueryParameter("issuer")).thenReturn("FreeOTP");
-        when(mMockUri.getQueryParameter("secret")).thenReturn("JBSWY3DPEHPK3PXP");
-
-        if (authority.equals("hotp")) {
-            when(mMockUri.getQueryParameter("counter")).thenReturn(counter);
-        }
-
-        try {
-            return new Token(mMockUri);
-        } catch (Token.TokenUriInvalidException e) {
-            e.printStackTrace();
-        }
-
-        return null;
-    }
 }

--- a/app/src/test/java/org/fedorahosted/freeotp/TokenPersistenceTest.java
+++ b/app/src/test/java/org/fedorahosted/freeotp/TokenPersistenceTest.java
@@ -18,7 +18,7 @@ import org.mockito.stubbing.Answer;
 
 import java.util.LinkedHashMap;
 
-import static org.fedorahosted.freeotp.TokenCodeTest.mockToken;
+import static org.fedorahosted.freeotp.TokenTestUtils.mockToken;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;

--- a/app/src/test/java/org/fedorahosted/freeotp/TokenTest.java
+++ b/app/src/test/java/org/fedorahosted/freeotp/TokenTest.java
@@ -7,7 +7,14 @@ import org.mockito.runners.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class TokenTest {
     @Test(expected = Token.TokenUriInvalidException.class)
-    public void TokenCtor_brokenURI_throwsCorrectException() throws Exception {
+    public void TokenCtor_brokenURI_throwsTokenUriInvalidException() throws Exception {
         new Token("otpauth://totp/?secret=...");
+    }
+    
+    @Test
+    public void TokenCtor_ZeroPeriod_ShouldNotThrowArithmeticException() throws Exception {
+        Token totpToken = TokenTestUtils.mockToken("totp", null, "foo", 0);
+        // Shouldn't throw from a divide by zero!
+        totpToken.generateCodes();
     }
 }

--- a/app/src/test/java/org/fedorahosted/freeotp/TokenTestUtils.java
+++ b/app/src/test/java/org/fedorahosted/freeotp/TokenTestUtils.java
@@ -1,0 +1,46 @@
+package org.fedorahosted.freeotp;
+
+import android.net.Uri;
+
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.when;
+
+// Who tests the test utils...?
+class TokenTestUtils {
+
+    public static Token mockToken(String authority, String counter) {
+        return mockToken(authority, counter, "FreeOTP:joe@google.com");
+    }
+
+    public static Token mockToken(String authority, String counter, String id) {
+        return mockToken(authority, counter, id, null);
+    }
+
+    public static Token mockToken(String authority, String counter, String id, Integer period) {
+        // https://github.com/google/google-authenticator/wiki/Key-Uri-Format
+        Uri mMockUri = Mockito.mock(Uri.class);
+
+        when(mMockUri.getScheme()).thenReturn("otpauth");
+        when(mMockUri.getAuthority()).thenReturn(authority);
+        when(mMockUri.getPath()).thenReturn(id);
+        when(mMockUri.getQueryParameter("issuer")).thenReturn("FreeOTP");
+        when(mMockUri.getQueryParameter("secret")).thenReturn("JBSWY3DPEHPK3PXP");
+
+        if (period != null) {
+            when(mMockUri.getQueryParameter("period")).thenReturn(String.valueOf(period.intValue()));
+        }
+
+        if (authority.equals("hotp")) {
+            when(mMockUri.getQueryParameter("counter")).thenReturn(counter);
+        }
+
+        try {
+            return new Token(mMockUri);
+        } catch (Token.TokenUriInvalidException e) {
+            e.printStackTrace();
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Rebased so it sits on top of previously accepted work while the .gitignore changes are discussed. This is only test code refactor and a small change to `Token.java` to handle the divide-by-zero instance.