### PR TITLE
Increased test coverage on Token.java

### DIFF
--- a/app/src/main/java/org/fedorahosted/freeotp/Token.java
+++ b/app/src/main/java/org/fedorahosted/freeotp/Token.java
@@ -57,23 +57,12 @@ public class Token {
     private int period;
 
     private Token(Uri uri, boolean internal) throws TokenUriInvalidException {
-        if (uri == null || !uri.getScheme().equals("otpauth"))
-            throw new TokenUriInvalidException();
-
-        if (uri.getAuthority().equals("totp"))
-            type = TokenType.TOTP;
-        else if (uri.getAuthority().equals("hotp"))
-            type = TokenType.HOTP;
-        else
-            throw new TokenUriInvalidException();
+        validateTokenURI(uri);
 
         String path = uri.getPath();
-        if (path == null)
-            throw new TokenUriInvalidException();
-
         // Strip the path of its leading '/'
-        for (int i = 0; path.charAt(i) == '/'; i++)
-            path = path.substring(1);
+        path = path.replaceFirst("/","");
+
         if (path.length() == 0)
             throw new TokenUriInvalidException();
 
@@ -139,6 +128,26 @@ public class Token {
             setIssuer(uri.getQueryParameter("issueralt"));
             setLabel(uri.getQueryParameter("labelalt"));
         }
+    }
+
+    private void validateTokenURI(Uri uri) throws TokenUriInvalidException{
+        if (uri == null) throw new TokenUriInvalidException();
+
+        if (uri.getScheme() == null || !uri.getScheme().equals("otpauth")){
+            throw new TokenUriInvalidException();
+        }
+
+        if (uri.getAuthority() == null) throw new TokenUriInvalidException();
+
+        if (uri.getAuthority().equals("totp")) {
+            type = TokenType.TOTP;
+        } else if (uri.getAuthority().equals("hotp"))
+            type = TokenType.HOTP;
+        else {
+            throw new TokenUriInvalidException();
+        }
+
+        if (uri.getPath() == null) throw new TokenUriInvalidException();
     }
 
     private String getHOTP(long counter) {

--- a/app/src/test/java/org/fedorahosted/freeotp/TokenCodeTest.java
+++ b/app/src/test/java/org/fedorahosted/freeotp/TokenCodeTest.java
@@ -45,7 +45,6 @@ public class TokenCodeTest {
     @Test
     public void getCurrentCode_hotpToken_returnsFixedHOTP() throws Exception {
         String code = hotpToken.generateCodes().getCurrentCode();
-        System.out.println(code);
         assertTrue(code.length() == 6);
         assertEquals("282760", code);
     }

--- a/app/src/test/java/org/fedorahosted/freeotp/TokenTest.java
+++ b/app/src/test/java/org/fedorahosted/freeotp/TokenTest.java
@@ -1,20 +1,232 @@
 package org.fedorahosted.freeotp;
 
+import android.net.Uri;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
+
+import java.lang.reflect.Field;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TokenTest {
     @Test(expected = Token.TokenUriInvalidException.class)
-    public void TokenCtor_brokenURI_throwsTokenUriInvalidException() throws Exception {
-        new Token("otpauth://totp/?secret=...");
+    public void TokenCtor_nullScheme_throwsTokenUriInvalidException() throws Exception {
+        Uri mockUri = Mockito.mock(Uri.class);
+        when(mockUri.getScheme()).thenReturn(null);
+
+        new Token(mockUri);
     }
-    
+
+    @Test(expected = Token.TokenUriInvalidException.class)
+    public void TokenCtor_invalidScheme_throwsTokenUriInvalidException() throws Exception {
+        Uri mockUri = Mockito.mock(Uri.class);
+        when(mockUri.getScheme()).thenReturn("borked");
+
+        new Token(mockUri);
+    }
+
+    @Test(expected = Token.TokenUriInvalidException.class)
+    public void TokenCtor_nullAuthority_throwsTokenUriInvalidException() throws Exception {
+        Uri mockUri = Mockito.mock(Uri.class);
+        when(mockUri.getScheme()).thenReturn("otpauth");
+        when(mockUri.getAuthority()).thenReturn(null);
+
+        new Token(mockUri);
+    }
+
+    @Test(expected = Token.TokenUriInvalidException.class)
+    public void TokenCtor_invalidAuthority_throwsTokenUriInvalidException() throws Exception {
+        Uri mockUri = Mockito.mock(Uri.class);
+        when(mockUri.getScheme()).thenReturn("otpauth");
+        when(mockUri.getAuthority()).thenReturn("borked");
+
+        new Token(mockUri);
+    }
+
+    @Test(expected = Token.TokenUriInvalidException.class)
+    public void TokenCtor_nullPath_throwsTokenUriInvalidException() throws Exception {
+        Uri mockUri = Mockito.mock(Uri.class);
+        when(mockUri.getScheme()).thenReturn("otpauth");
+        when(mockUri.getAuthority()).thenReturn("totp");
+        when(mockUri.getPath()).thenReturn(null);
+
+        new Token(mockUri);
+    }
+
+    @RunWith(Parameterized.class)
+    public static class ParameterizedPathsTest {
+        private String path;
+
+        public ParameterizedPathsTest (String path) {
+            this.path = path;
+        }
+
+        @Parameterized.Parameters
+        public static String[] paths() {
+            return new String[]{
+                    "//////",
+                    "/agda/asdg/sag/aga:AGSDSAgA@@@:://adg",
+                    "@email/",
+                    ""
+            };
+        }
+
+        @Test(expected = Token.TokenUriInvalidException.class)
+        public void TokenCtor_invalidPath_throwsTokenUriInvalidException() throws Exception {
+            Uri mockUri = Mockito.mock(Uri.class);
+            when(mockUri.getScheme()).thenReturn("otpauth");
+            when(mockUri.getAuthority()).thenReturn("totp");
+            when(mockUri.getPath()).thenReturn(path);
+
+            new Token(mockUri);
+        }
+    }
+
+    @Test(expected = Token.TokenUriInvalidException.class)
+    public void TokenCtor_nullIssuer_throwsTokenUriInvalidException() throws Exception {
+        Uri mockUri = Mockito.mock(Uri.class);
+        when(mockUri.getScheme()).thenReturn("otpauth");
+        when(mockUri.getAuthority()).thenReturn("totp");
+        when(mockUri.getPath()).thenReturn("FreeOTP:joe@cool.com");
+        when(mockUri.getQueryParameter("issuer")).thenReturn(null);
+
+        new Token(mockUri);
+    }
+
+    @Test(expected = Token.TokenUriInvalidException.class)
+    public void TokenCtor_invalidIssuer_throwsTokenUriInvalidException() throws Exception {
+        Uri mockUri = Mockito.mock(Uri.class);
+        when(mockUri.getScheme()).thenReturn("otpauth");
+        when(mockUri.getAuthority()).thenReturn("totp");
+        when(mockUri.getPath()).thenReturn("FreeOTP:joe@cool.com");
+        when(mockUri.getQueryParameter("issuer")).thenReturn("borked");
+
+        new Token(mockUri);
+    }
+
+    @Test(expected = Token.TokenUriInvalidException.class)
+    public void TokenCtor_nullSecret_throwsTokenUriInvalidException() throws Exception {
+        Uri mockUri = Mockito.mock(Uri.class);
+        when(mockUri.getScheme()).thenReturn("otpauth");
+        when(mockUri.getAuthority()).thenReturn("totp");
+        when(mockUri.getPath()).thenReturn("FreeOTP");
+        when(mockUri.getQueryParameter("issuer")).thenReturn("FreeOTP");
+        when(mockUri.getQueryParameter("secret")).thenReturn(null);
+
+        new Token(mockUri);
+    }
+
+    @Test(expected = Token.TokenUriInvalidException.class)
+    public void TokenCtor_invalidSecret_throwsTokenUriInvalidException() throws Exception {
+        Uri mockUri = Mockito.mock(Uri.class);
+        when(mockUri.getScheme()).thenReturn("otpauth");
+        when(mockUri.getAuthority()).thenReturn("totp");
+        when(mockUri.getPath()).thenReturn("borked");
+        when(mockUri.getQueryParameter("issuer")).thenReturn("FreeOTP");
+        when(mockUri.getQueryParameter("secret")).thenReturn("κόσμε");
+
+        new Token(mockUri);
+    }
+
+    @Test
+    public void TokenCtor_nullPeriod_setsDefaultValue() throws Exception {
+        Uri mockUri = Mockito.mock(Uri.class);
+        when(mockUri.getScheme()).thenReturn("otpauth");
+        when(mockUri.getAuthority()).thenReturn("totp");
+        when(mockUri.getPath()).thenReturn("FreeOTP");
+        when(mockUri.getQueryParameter("issuer")).thenReturn("FreeOTP");
+        when(mockUri.getQueryParameter("secret")).thenReturn("foobar");
+        when(mockUri.getQueryParameter("period")).thenReturn(null);
+
+        // When period is not defined it should get set to the default value.
+
+        Token token = new Token(mockUri);
+        Field f = Token.class.getDeclaredField("period");
+        f.setAccessible(true);
+        Integer period = (Integer) f.get(token);
+        assertEquals((Integer) 30, period);
+    }
+
+    @Test
+    public void TokenCtor_invalidPeriod_setsDefaultValue() throws Exception {
+        Uri mockUri = Mockito.mock(Uri.class);
+        when(mockUri.getScheme()).thenReturn("otpauth");
+        when(mockUri.getAuthority()).thenReturn("totp");
+        when(mockUri.getPath()).thenReturn("borked");
+        when(mockUri.getQueryParameter("issuer")).thenReturn("FreeOTP");
+        when(mockUri.getQueryParameter("secret")).thenReturn("foobar");
+        when(mockUri.getQueryParameter("period")).thenReturn("-1");
+
+        // When period is invalid it should get set to the default value.
+
+        Token token = new Token(mockUri);
+        Field f = Token.class.getDeclaredField("period");
+        f.setAccessible(true);
+        Integer period = (Integer) f.get(token);
+        assertEquals((Integer) 30, period);
+    }
+
+    @Test(expected = Token.TokenUriInvalidException.class)
+    public void TokenCtor_invalidPeriodType_throwsTokenUriInvalidException() throws Exception {
+        Uri mockUri = Mockito.mock(Uri.class);
+        when(mockUri.getScheme()).thenReturn("otpauth");
+        when(mockUri.getAuthority()).thenReturn("totp");
+        when(mockUri.getPath()).thenReturn("borked");
+        when(mockUri.getQueryParameter("issuer")).thenReturn("FreeOTP");
+        when(mockUri.getQueryParameter("secret")).thenReturn("foobar");
+        when(mockUri.getQueryParameter("period")).thenReturn("not a number");
+
+        new Token(mockUri);
+    }
+
     @Test
     public void TokenCtor_ZeroPeriod_ShouldNotThrowArithmeticException() throws Exception {
         Token totpToken = TokenTestUtils.mockToken("totp", null, "foo", 0);
         // Shouldn't throw from a divide by zero!
         totpToken.generateCodes();
+    }
+
+    @Test
+    public void TokenCtor_hotp_nullCounter_setsDefaultValue() throws Exception {
+        Uri mockUri = Mockito.mock(Uri.class);
+        when(mockUri.getScheme()).thenReturn("otpauth");
+        when(mockUri.getAuthority()).thenReturn("hotp");
+        when(mockUri.getPath()).thenReturn("FreeOTP");
+        when(mockUri.getQueryParameter("issuer")).thenReturn("FreeOTP");
+        when(mockUri.getQueryParameter("secret")).thenReturn("foobar");
+        when(mockUri.getQueryParameter("counter")).thenReturn(null);
+
+        // When counter is not defined it should get set to the default value.
+
+        Token token = new Token(mockUri);
+        Field f = Token.class.getDeclaredField("counter");
+        f.setAccessible(true);
+        Long counter = (Long) f.get(token);
+        assertEquals(Long.valueOf(0), counter);
+    }
+
+    @Test
+    public void TokenCtor_hotp_setsCounterIfValid() throws Exception {
+        Uri mockUri = Mockito.mock(Uri.class);
+        when(mockUri.getScheme()).thenReturn("otpauth");
+        when(mockUri.getAuthority()).thenReturn("hotp");
+        when(mockUri.getPath()).thenReturn("borked");
+        when(mockUri.getQueryParameter("issuer")).thenReturn("FreeOTP");
+        when(mockUri.getQueryParameter("secret")).thenReturn("foobar");
+        when(mockUri.getQueryParameter("counter")).thenReturn("-999");
+
+        // When counter is invalid it should get set to the default value.
+
+        Token token = new Token(mockUri);
+        Field f = Token.class.getDeclaredField("counter");
+        f.setAccessible(true);
+        Long counter = (Long) f.get(token);
+        assertEquals(Long.valueOf(-999), counter);
     }
 }


### PR DESCRIPTION
In adding more test coverage to Token.java I found a few edge cases that required some minor code changes to the `TokenCtor` in `Token.java`. I extracted the ugly null checks out to a helper method and changed the trim leading slash to something that didn't throw an index-out-of-range. 

After doing this I ran test coverage and I'm comfortable with the levels of these classes: 

Element | Class | Method | Line
-- | -- | -- | --
Token | 100% (4/4) | 68% (15/22) | 65% (98/150)
TokenCode | 100% (1/1) | 87% (7/8) | 76% (26/34)
TokenPersistence | 100% (2/2) | 90% (10/11) | 71% (35/49)

The remaining uncovered code is mostly just boilerplate or error handling for Java core classes. 

I also added some parameterized testing for the Uri paths, this should make it easy to add some arbitrary fuzz corpus later if there are still issues been raised around invalid inputs.
