### PR TITLE
Added maven URL to project gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,9 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com'
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.0-alpha9'


### PR DESCRIPTION
gradle 3.x.x alpha requires the google maven url for
tools like FindBugs to function properly