### PR TITLE
Prevent screencaps in ScanActivity

### DIFF
--- a/app/src/main/java/org/fedorahosted/freeotp/add/ScanActivity.java
+++ b/app/src/main/java/org/fedorahosted/freeotp/add/ScanActivity.java
@@ -38,6 +38,7 @@ import android.view.Surface;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 import android.view.View;
+import android.view.WindowManager;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
 
@@ -133,6 +134,7 @@ public class ScanActivity extends Activity implements SurfaceHolder.Callback {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
         setContentView(R.layout.scan);
         mScanAsyncTask.execute();
     }


### PR DESCRIPTION
Added FLAG_SECURE to ScanActivity
Fixes freeotp/freeotp-android#124

Verified fix on AVD via `screencap` command in adb shell.
```
generic_x86:/ $ ls -alh sdcard/Pictures/                                       
total 36K
drwxrwx--x  2 root sdcard_rw 4.0K 2017-09-07 23:17 .
drwxrwx--x 12 root sdcard_rw 4.0K 2017-09-07 23:17 ..
-rw-rw----  1 root sdcard_rw    0 2017-09-07 23:15 after.png
-rw-rw----  1 root sdcard_rw  28K 2017-09-07 23:16 before.png
```
