### PR TITLE
fix(gradle): use google repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {


### PR DESCRIPTION
This is similar to https://github.com/freeotp/freeotp-android/pull/119 but uses `google()` instead of URL