### PR TITLE
fix(gradle): use stable tools 2.3.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-alpha9'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 


### PR DESCRIPTION
The current setting requires Android Studio Alpha release, I suggest to use the tools from stable.