### PR TITLE
Use runtime permissions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,8 +1,9 @@
 apply plugin: 'com.android.application'
 
 dependencies {
-    compile 'com.google.zxing:core:3.3.0'
+    compile "com.android.support:support-core-utils:26.0.2"
     compile 'com.google.code.gson:gson:2.8.1'
+    compile 'com.google.zxing:core:3.3.0'
     compile 'com.squareup.picasso:picasso:2.5.2'
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,15 +26,15 @@
 
     <uses-sdk
         android:minSdkVersion="14"
-        android:targetSdkVersion="20" />
+        android:targetSdkVersion="26" />
 
     <supports-screens
-        android:smallScreens="true"
-        android:normalScreens="true"
+        android:anyDensity="true"
         android:largeScreens="true"
-        android:xlargeScreens="true"
+        android:normalScreens="true"
         android:resizeable="true"
-        android:anyDensity="true" />
+        android:smallScreens="true"
+        android:xlargeScreens="true" />
 
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.INTERNET" />
@@ -79,10 +79,10 @@
 
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name"
             android:clearTaskOnLaunch="true"
-            android:launchMode="singleTask"
             android:configChanges="orientation|screenSize"
+            android:label="@string/app_name"
+            android:launchMode="singleTask"
             >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -92,8 +92,13 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="otpauth" android:host="totp" />
-                <data android:scheme="otpauth" android:host="hotp" />
+
+                <data
+                    android:host="totp"
+                    android:scheme="otpauth" />
+                <data
+                    android:host="hotp"
+                    android:scheme="otpauth" />
             </intent-filter>
         </activity>
     </application>

--- a/app/src/main/java/org/fedorahosted/freeotp/MainActivity.java
+++ b/app/src/main/java/org/fedorahosted/freeotp/MainActivity.java
@@ -36,22 +36,29 @@
 
 package org.fedorahosted.freeotp;
 
-import org.fedorahosted.freeotp.add.AddActivity;
-import org.fedorahosted.freeotp.add.ScanActivity;
-
+import android.Manifest;
 import android.app.Activity;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.database.DataSetObserver;
 import android.net.Uri;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.MenuItem.OnMenuItemClickListener;
 import android.view.View;
 import android.view.WindowManager.LayoutParams;
 import android.widget.GridView;
+import android.widget.Toast;
+
+import org.fedorahosted.freeotp.add.AddActivity;
+import org.fedorahosted.freeotp.add.ScanActivity;
 
 public class MainActivity extends Activity implements OnMenuItemClickListener {
+    private static final int PERMISSIONS_REQUEST_CAMERA = 200;
     private TokenAdapter mTokenAdapter;
     private DataSetObserver mDataSetObserver;
 
@@ -111,21 +118,55 @@ public class MainActivity extends Activity implements OnMenuItemClickListener {
     @Override
     public boolean onMenuItemClick(MenuItem item) {
         switch (item.getItemId()) {
-        case R.id.action_scan:
-            startActivity(new Intent(this, ScanActivity.class));
-            overridePendingTransition(R.anim.fadein, R.anim.fadeout);
-            return true;
+            case R.id.action_scan:
+                startScanActivity();
+                return true;
 
-        case R.id.action_add:
-            startActivity(new Intent(this, AddActivity.class));
-            return true;
+            case R.id.action_add:
+                startActivity(new Intent(this, AddActivity.class));
+                return true;
 
-        case R.id.action_about:
-            startActivity(new Intent(this, AboutActivity.class));
-            return true;
+            case R.id.action_about:
+                startActivity(new Intent(this, AboutActivity.class));
+                return true;
         }
 
         return false;
+    }
+
+    private void startScanActivity() {
+        //Check that Camera permission has been granted before starting the scan activity
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA)
+                != PackageManager.PERMISSION_GRANTED) {
+            //Camera permission not granted, so request it
+            ActivityCompat.requestPermissions(this,
+                    new String[]{Manifest.permission.CAMERA}, PERMISSIONS_REQUEST_CAMERA);
+        } else {
+            //Camera permission granted, so start scan activity
+            startActivity(new Intent(this, ScanActivity.class));
+            overridePendingTransition(R.anim.fadein, R.anim.fadeout);
+        }
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String permissions[],
+                                           @NonNull int[] grantResults) {
+        switch (requestCode) {
+            case PERMISSIONS_REQUEST_CAMERA: {
+                // If request is cancelled, the result array is empty.
+                if (grantResults.length > 0
+                        && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                    startScanActivity();
+                } else {
+                    //Camera permission was not granted. Show a message and remain in this activity
+                    showCameraRationale();
+                }
+            }
+        }
+    }
+
+    private void showCameraRationale() {
+        Toast.makeText(this, R.string.camera_justification, Toast.LENGTH_LONG).show();
     }
 
     @Override

--- a/app/src/main/res/layout/scan.xml
+++ b/app/src/main/res/layout/scan.xml
@@ -36,15 +36,16 @@
         android:layout_height="match_parent"
         android:layout_gravity="center"
         android:layout_margin="64dp">
+
         <ImageView
             android:id="@+id/image"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_gravity="center"
-            android:scaleType="fitCenter"
-            android:src="@drawable/scan"
             android:alpha=".6"
-            />
+            android:contentDescription="@string/capture_description"
+            android:scaleType="fitCenter"
+            android:src="@drawable/scan" />
 
         <ProgressBar
             android:id="@+id/progress"
@@ -61,8 +62,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
-        android:visibility="invisible"
-        android:textColor="@android:color/primary_text_dark"
         android:text="@string/error_camera_open"
+        android:textColor="@android:color/primary_text_dark"
+        android:visibility="invisible"
         />
 </FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,7 +30,9 @@
     <string name="link_website">&lt;a href=&quot;http://freeotp.github.io&quot;&gt;website&lt;/a&gt;</string>
     <string name="link_apache2">&lt;a href=&quot;http://www.apache.org/licenses/LICENSE-2.0.html&quot;&gt;Apache 2.0&lt;/a&gt;</string>
 
-    <string name="error_camera_open">Error while opening camera!</string>
+    <string name="camera_justification">FreeOTP needs access to the camera to be able to scan QR codes</string>
+    <string name="capture_description">Point the camera at the QR code</string>
+    <string name="error_camera_open">Error while opening the camera!</string>
 
     <string name="delete_summary">This is your last chance: if you delete this token, it will be gone forever. It will not be disabled on the server.</string>
     <string name="delete_question">Delete this token?</string>

--- a/build.gradle
+++ b/build.gradle
@@ -12,5 +12,8 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 }


### PR DESCRIPTION
Allow FreeOTP to use the runtime permission system when running on a device with Marshmallow or newer #137  