### PR TITLE
Fix/permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,12 @@ Play](https://play.google.com/store/apps/details?id=org.fedorahosted.freeotp)
 ## Contributing
 
 Pull requests on GitHub are welcome under the Apache 2.0 license, see [COPYING](COPYING).
+
+## Permissions
+
+The FreeOTP app uses the following permissions
+
+| Permission | Usage                    | Required | Permission type |
+|------------|--------------------------|----------|-----------------|
+| Camera     | Recognition of QR codes  | No       | Dangerous       |
+| Internet   | Token image provisioning | No       | Normal          |

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,7 +38,6 @@
 
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-feature android:name="android.hardware.camera" android:required="false" />
     <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
 


### PR DESCRIPTION
* The PR removes the  READ_EXTERNAL_STORAGE permission
The TokenImage is picked by using the ACTION_PICK Intent and therefore FreeOTP doesn't need this permission
* Adds information about used permissions in README.md