### PR TITLE
Add GET_CONTENT and INSERT actions to support 3rd party app integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,4 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-26.0.2
-    - android-26
+    - android-28

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 dependencies {
-    compile 'com.google.zxing:core:3.3.0'
-    compile 'com.google.code.gson:gson:2.8.2'
-    compile 'com.squareup.picasso:picasso:2.5.2'
-    compile 'io.fotoapparat.fotoapparat:library:1.4.1'
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:1.10.19'
+    implementation 'com.google.zxing:core:3.3.0'
+    implementation 'com.google.code.gson:gson:2.8.2'
+    implementation 'com.squareup.picasso:picasso:2.5.2'
+    implementation 'io.fotoapparat.fotoapparat:library:1.4.1'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:1.10.19'
 }
 
 allprojects {
@@ -28,9 +28,8 @@ android {
 
     defaultConfig {
         minSdkVersion 23
-        targetSdkVersion 26
+        targetSdkVersion 28
     }
 
-    compileSdkVersion 26       // NOTE: update build-tools-* in .travis.yml
-    buildToolsVersion '26.0.2' // NOTE: update build-tools-* in .travis.yml
+    compileSdkVersion 28       // NOTE: update build-tools-* in .travis.yml
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,10 +24,6 @@
     android:versionCode="17"
     android:versionName="1.5" >
 
-    <uses-sdk
-        android:minSdkVersion="23"
-        android:targetSdkVersion="26" />
-
     <supports-screens
         android:smallScreens="true"
         android:normalScreens="true"
@@ -84,6 +80,18 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="otpauth" android:host="totp" />
+                <data android:scheme="otpauth" android:host="hotp" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.INSERT" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="otpauth" android:host="totp" />
+                <data android:scheme="otpauth" android:host="hotp" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.GET_CONTENT" />
+                <category android:name="android.intent.category.DEFAULT" />
                 <data android:scheme="otpauth" android:host="totp" />
                 <data android:scheme="otpauth" android:host="hotp" />
             </intent-filter>

--- a/app/src/main/java/org/fedorahosted/freeotp/TokenPersistence.java
+++ b/app/src/main/java/org/fedorahosted/freeotp/TokenPersistence.java
@@ -43,7 +43,7 @@ import java.util.List;
 import java.util.UUID;
 
 public class TokenPersistence {
-    private static final String NAME  = "tokens";
+    protected static final String NAME  = "tokens";
     private static final String ORDER = "tokenOrder";
     private final SharedPreferences prefs;
     private final Gson gson;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,6 +34,16 @@
     <string name="delete_summary">This is your last chance: if you delete this token, it will be gone forever. It will not be disabled on the server.</string>
     <string name="delete_question">Delete this token?</string>
 
+    <string name="attention">Attention</string>
+    <string name="error">Error</string>
+    <string name="allow">Allow</string>
+    <string name="deny">Deny</string>
+    <string name="default_appname">An unspecified app</string>
+    <string name="request_code">" has requested a code for token "</string>
+    <string name="request_install_token">" has requested to install a token for "</string>
+    <string name="bad_token_uri">"Bad token uri: "</string>
+    <string name="token_already_exists">Token \"%s\" already exists</string>
+
     <string-array name="algorithms">
         <item>MD5</item>
         <item>SHA1</item>

--- a/build.gradle
+++ b/build.gradle
@@ -5,12 +5,13 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
 }
 
 allprojects {
     repositories {
+        google()
         jcenter()
         maven { url 'https://jitpack.io' }
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Sat Dec 22 16:33:13 MST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
This branch adds support for 3rd party app integration/automation using
standard "otpauth://" URIs
(https://github.com/google/google-authenticator/wiki/Key-Uri-Format).
The GET_CONTENT intent action will return the current code for an
existing token. The INSERT action will install a new token and return
the current code (and the token secret to allow stateless operation by
the intent sender). Both actions are subject to user confirmation.

These two actions will allow a 3rd party app to alleviate the cubersome
and error prone user process of being prompted for an OTP code,
switching to FreeOTP, memorizing or copying the code to the clipboard,
switch back to the original app, and finally entering the code. The 3rd
party app should appropriately handle the exception cases of FreeOTP not
being installed or the user denying the requested action.