### PR TITLE
Add Google maven repo to all projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,5 +13,6 @@ allprojects {
     repositories {
         jcenter()
         maven { url 'https://jitpack.io' }
+        google()
     }
 }


### PR DESCRIPTION
Allows downloading of support libraries and Jetpack components.