### PR TITLE
Update to Android 10 (API 29)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: android
-
+dist: trusty
 android:
   components:
     - tools
     - platform-tools
-    - build-tools-26.0.2
-    - android-26
+    - build-tools-29.0.2
+    - android-29
+    - extra-google-m2repository

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 dependencies {
-    compile 'com.google.zxing:core:3.3.0'
-    compile 'com.google.code.gson:gson:2.8.2'
-    compile 'com.squareup.picasso:picasso:2.5.2'
-    compile 'io.fotoapparat.fotoapparat:library:1.4.1'
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:1.10.19'
+    implementation 'com.google.zxing:core:3.3.0'
+    implementation 'com.google.code.gson:gson:2.8.5'
+    implementation 'com.squareup.picasso:picasso:2.5.2'
+    implementation 'io.fotoapparat.fotoapparat:library:1.4.1'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:1.10.19'
 }
 
 allprojects {
@@ -28,9 +28,9 @@ android {
 
     defaultConfig {
         minSdkVersion 23
-        targetSdkVersion 26
+        targetSdkVersion 29
     }
 
-    compileSdkVersion 26       // NOTE: update build-tools-* in .travis.yml
-    buildToolsVersion '26.0.2' // NOTE: update build-tools-* in .travis.yml
+    compileSdkVersion 29       // NOTE: update build-tools-* in .travis.yml
+    buildToolsVersion '29.0.2' // NOTE: update build-tools-* in .travis.yml
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,10 +24,6 @@
     android:versionCode="17"
     android:versionName="1.5" >
 
-    <uses-sdk
-        android:minSdkVersion="23"
-        android:targetSdkVersion="26" />
-
     <supports-screens
         android:smallScreens="true"
         android:normalScreens="true"

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.5.1'
     }
 }
 
@@ -13,5 +13,8 @@ allprojects {
     repositories {
         jcenter()
         maven { url 'https://jitpack.io' }
+        // Android studio requires google m2 to obtain support libraries, even though
+        // we are not directly referencing them at present.
+        google()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Fri Oct 04 08:34:48 EDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
* Add Google maven repo to all projects
* Gradle 4.1 -> 5.4.1
* Build tools 3.0.1 -> 3.5.1
* Android sdk -> 29
* Android build tools -> 29.0.2
* Remove obsolete <uses-sdk> tag in AndroidManifest.xml - generated by gradle instead
* Bump gson to 2.8.5