### PR TITLE
Remove confusing random hint text, make conventional

### DIFF
--- a/app/src/main/res/layout/metadata.xml
+++ b/app/src/main/res/layout/metadata.xml
@@ -18,7 +18,7 @@
         android:layout_height="48dp"
         android:layout_toRightOf="@id/image"
         android:layout_marginTop="4dp"
-        android:hint="jdoe@example.com"
+        android:hint="Example Site"
         android:inputType="textNoSuggestions"
         android:textAppearance="?android:attr/textAppearanceSmallInverse" />
 
@@ -29,7 +29,7 @@
         android:layout_toRightOf="@id/image"
         android:layout_below="@id/issuer"
         android:layout_marginBottom="4dp"
-        android:hint="18c5d06cfcbd4927"
+        android:hint="jdoe@example.com"
         android:inputType="textNoSuggestions"
         android:textAppearance="?android:attr/textAppearanceSmallInverse" />
 </RelativeLayout>


### PR DESCRIPTION
Following convention I suggest "Example Site" as the issuer hint, and "jdoe@example.com" as the label hint - consistent with the screenshots at https://freeotp.github.io/ . If one does not scan a QR code to add a key: the existing random looking hint of "18c5d06cfcbd4927" for android:id="@+id/label" is confusing in a screen that already asks user to enter random strings in aid of math that many do not understand. I love this app but to show how confusing this is it was easier for me, who knows computer languages, to find the file on Github and see "Oh, it's a label" from android:id="@+id/label" - than to work out purpose of field when seeing this random hint text for the 1st time.  The IOS version (judging by https://github.com/freeotp/freeotp-ios/blob/master/FreeOTP/Base.lproj/Main.storyboard ) also seems to have better hint text for issuer and label. Hope to save other Android users any confusion. Thank you.