### PR TITLE
Ignore casing of token algorithm

### DIFF
--- a/mobile/src/main/java/org/fedorahosted/freeotp/Token.java
+++ b/mobile/src/main/java/org/fedorahosted/freeotp/Token.java
@@ -153,7 +153,7 @@ public class Token {
 
         boolean safeAlgo = false;
         for (String algo : SAFE_ALGOS) {
-            if (pair.second.getAlgorithm().equals(algo)) {
+            if (pair.second.getAlgorithm().equalsIgnoreCase(algo)) {
                 safeAlgo = true;
                 break;
             }


### PR DESCRIPTION
Accept token algorithm specified in lowercase (e.g. `sha512`) or any other casing (e.g. `Sha512`) in addition to upper case only.

fixes: #288