### PR TITLE
Tests: Fix TokenCompatTest failures

### DIFF
--- a/mobile/src/androidTest/java/org/fedorahosted/freeotp/TokenCompatTest.java
+++ b/mobile/src/androidTest/java/org/fedorahosted/freeotp/TokenCompatTest.java
@@ -301,6 +301,9 @@ public class TokenCompatTest extends TestCase implements SelectableAdapter.Event
         TokenPersistence tokenBackup = new TokenPersistence(mContext);
         String pwd = "MyM4sterPassw0rd";
 
+        KeyStore ks = KeyStore.getInstance("AndroidKeyStore");
+        ks.load(null);
+
         SharedPreferences old = mContext.getSharedPreferences("tokens", Context.MODE_PRIVATE);
         SharedPreferences cur = mContext.getSharedPreferences("tokenStore", Context.MODE_PRIVATE);
         SharedPreferences bkp = mContext.getSharedPreferences("tokenBackup", Context.MODE_PRIVATE);
@@ -317,7 +320,10 @@ public class TokenCompatTest extends TestCase implements SelectableAdapter.Event
         assertEquals(3, bkp.getAll().size());
 
         // Delete token
+        JSONArray oldtoken = new JSONArray(cur.getString("tokenOrder", null));
+        String olduuid = oldtoken.getString(0);
         cur.edit().clear().commit();
+        ks.deleteEntry(olduuid);
         assertEquals(0, cur.getAll().size());
 
         // Perform restore
@@ -330,8 +336,6 @@ public class TokenCompatTest extends TestCase implements SelectableAdapter.Event
         UUID uuid = UUID.fromString(order.getString(0));
 
         // Make sure the secret is stored in the key store.
-        KeyStore ks = KeyStore.getInstance("AndroidKeyStore");
-        ks.load(null);
         assertTrue(ks.containsAlias(uuid.toString()));
         Key key = ks.getKey(uuid.toString(), null);
 

--- a/mobile/src/androidTest/java/org/fedorahosted/freeotp/TokenPersistenceTest.java
+++ b/mobile/src/androidTest/java/org/fedorahosted/freeotp/TokenPersistenceTest.java
@@ -68,7 +68,14 @@ public class TokenPersistenceTest implements SelectableAdapter.EventListener {
     }
 
     private Adapter wipeAndRestore(SharedPreferences tokenStore) throws TokenPersistence.BadPasswordException,
-            GeneralSecurityException, IOException {
+            GeneralSecurityException, IOException, JSONException {
+        JSONArray oldtoken = new JSONArray(tokenStore.getString("tokenOrder", null));
+        KeyStore ks = KeyStore.getInstance("AndroidKeyStore");
+        ks.load(null);
+
+        for (int i = 0; i < oldtoken.length(); i++) {
+            ks.deleteEntry(oldtoken.getString(i));
+        }
         tokenStore.edit().clear().commit();
         assertEquals(0, tokenStore.getAll().size());
 


### PR DESCRIPTION
Now that we check for existing tokens on restore, tests removing tokens completely requires removal from the keystore prior to restore.