### PR TITLE
Restore: Do not overwrite master key in keystore

### DIFF
--- a/mobile/src/main/java/org/fedorahosted/freeotp/TokenPersistence.java
+++ b/mobile/src/main/java/org/fedorahosted/freeotp/TokenPersistence.java
@@ -163,13 +163,6 @@ public class TokenPersistence {
             throw new BadPasswordException();
         }
 
-        KeyProtection kp = new KeyProtection.Builder(KeyProperties.PURPOSE_ENCRYPT)
-                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
-                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
-                .build();
-
-        mKeyStore.setEntry(MASTER, new KeyStore.SecretKeyEntry(sk), kp);
-
         for (Map.Entry<String, ?> item : mBackups.getAll().entrySet()) {
             JSONObject obj;
             String uuid = item.getKey();


### PR DESCRIPTION
During the restore operation, we decrypt the master key from the restored data and store it back into the keystore, overwriting an existing master key.

This causes issues when a different master password is set on the current device.