### PR TITLE
Remove unused strings

### DIFF
--- a/mobile/src/main/res/values-de/strings.xml
+++ b/mobile/src/main/res/values-de/strings.xml
@@ -26,10 +26,8 @@
     <string name="done">Fertig</string>
     <string name="close">Schließen</string>
     <string name="save">Speichern</string>
-    <string name="restore">Wiederherstellen aus Backup</string>
     <string name="about">Über</string>
     <string name="auto_copy_clipboard">Automatische Zwischenablage</string>
-    <string name="manual_add">Manuell hinzufügen</string>
     <string name="cancel">Abbrechen</string>
     <string name="delete">Löschen</string>
     <string name="move_up">Nach Oben bewegen</string>
@@ -66,8 +64,6 @@
     <string name="main_invalidated_title">Schlüssel ungültig gemacht!</string>
     <string name="main_invalidated_message">Der Schlüssel für dieses Token wurde vom Android Key Store für ungültig erklärt. Dies kann durch eine Änderung der Einstellungen Ihres Sperrbildschirms verursacht worden sein. Das Token wurde entfernt. Bitte kontaktieren Sie Ihren Token-Anbieter.</string>
     <string name="main_restore_title">Aus Backup wiederherstellen</string>
-    <string name="main_backup_android_title">Android-Backup</string>
-    <string name="main_backup_android_alert">Verschlüsselte FreeOTP-Token-Daten sind in den Sicherungs- und Wiederherstellungsvorgängen von Android Backup enthalten. Android-Backups müssen aktiviert sein, um diese Funktion nutzen zu können.&lt;br/&gt;&lt;br/&gt;Weitere Informationen finden Sie unter &lt;a href=&quot;https://developer.android.com/guide/topics/data/backup&quot;&gt;Überblick zur Datensicherung&lt;/a&gt; und &lt;a href=&quot;https://support.google.com/android/answer/2819582?hl=de&quot;&gt;Android-Backups&lt;/a&gt;</string>
     <string name="main_restore_message">Bitte geben Sie das Backup-Passwort ein</string>
     <string name="main_restore_bad_password">Ungültiges Passwort</string>
     <string name="main_restore_cancel_title">Wiederherstellen abbrechen?</string>
@@ -79,7 +75,6 @@
     <string name="password">Passwort</string>
     <string name="password_confirm">Passwort bestätigen</string>
     <string name="password_info">Token-Backups ermöglichen Ihnen die Wiederherstellung nach einem Datenverlust und die mühelose Übertragung Ihrer Token auf ein neues Gerät.\n\nBackups werden mit dem unten angegebenen Passwort verschlüsselt. Die Sicherheit Ihrer Backups hängt von einem starken Passwort ab.\n\nDas FreeOTP Sicherheitsmodell schreibt vor, dass dieses Passwort zu einem späteren Zeitpunkt NICHT geändert werden kann. Bitte berücksichtigen Sie dies bei der Wahl Ihres Passworts.</string>
-    <string name="password_weak">Das Passwort ist zu schwach!</string>
     <string name="password_match">Die Passwörter stimmen nicht überein!</string>
 
 
@@ -113,8 +108,6 @@
     <string name="manual_add_token">Token hinzufügen</string>
     <string name="manual_accessibility_algorithm">Token-Algorithmus</string>
     <string name="manual_accessibility_interval">Token-Interval</string>
-    <string name="manual_invalid_title">Token ist ungültig!</string>
-    <string name="manual_invalid_message">Der Token, den Sie hinzufügen möchten, ist ungültig. Bitte überprüfen Sie, ob jedes Feld gemäß dem OTP-Key-URI-Format gültig ist.</string>
     <string name="edit_token">Token bearbeiten</string>
     <string name="get_started">LOSLEGEN</string>
 
@@ -125,7 +118,6 @@
     <string name="keystore_migration_explanation">FreeOTP-Tokens sind jetzt in den Android Keystore migriert! Dies führt zu einer erhöhten Sicherheit der Token-Geheimnisse, allerdings ist das Schlüsselmaterial nicht exportierbar. \n\nBackup- und Wiederherstellungsfunktionen wurden hinzugefügt, um sicherzustellen, dass Token wiederhergestellt werden können. Sie werden aufgefordert, ein Master-Passwort zu erstellen, um verschlüsselte Token-Backups einzurichten.</string>
     <string name="manual_backup_explanation">Alternativ dazu kann eine verschlüsselte Sicherungsdatei in der App auf einen externen Speicher exportiert werden. Das Menü in der oberen Symbolleiste enthält jetzt die Einträge "Sichern" und "Wiederherstellen", um diese manuelle Sicherungsmethode zu nutzen.</string>
     <string name="google_auto_backup_link">FreeOTP kann an der automatischen Sicherungs- und Wiederherstellungsfunktion von Android teilnehmen. Dieser &lt;a href=&quot;https://support.google.com/android/answer/2819582?hl=en&quot;&gt;Google-Link&lt;/a&gt; enthält Informationen darüber, wie diese Sicherungsmethode genutzt werden kann.</string>
-    <string name="hello_blank_fragment">Hello blank fragment</string>
     <string name="backup_imageview">backup imageView</string>
     <string name="keystore_image">keystore image</string>
     <string name="android_keystore_title">Android Keystore</string>

--- a/mobile/src/main/res/values-nb/strings.xml
+++ b/mobile/src/main/res/values-nb/strings.xml
@@ -7,10 +7,8 @@
     <string name="done">Ferdig</string>
     <string name="close">Lukk</string>
     <string name="save">Lagre</string>
-    <string name="restore">Gjenopprett Fra Sikkerhetskopi</string>
     <string name="about">Om</string>
     <string name="auto_copy_clipboard">Auto Utklippstavle</string>
-    <string name="manual_add">Legg Til Manuelt</string>
     <string name="cancel">Avbryt</string>
     <string name="delete">Slett</string>
     <string name="move_up">Flytt Opp</string>
@@ -47,8 +45,6 @@
     <string name="main_invalidated_title">Nøkkel ugyldiggjort!</string>
     <string name="main_invalidated_message">Nøkkelen er ugyldiggjort av Android KeyStore. Dette kan ha vært på grunn av en endring i skjermlåsinnstillingene dine. Nøkkelen er fjernet. Vennligst kontakt leverandøren av nøkkelen.</string>
     <string name="main_restore_title">Gjenopprett fra sikkerhetskopi</string>
-    <string name="main_backup_android_title">Android-sikkerhetskopi</string>
-    <string name="main_backup_android_alert">Krypterte FreeOTP-nøkkeldata er inkludert i sikkerhetskopierings- og gjenopprettingsoperasjoner som utføres av Android-sikkerhetskopiering. Android-sikkerhetskopier må være aktivert for å dra nytte av denne funksjonen.&lt;br/&gt;&lt;br/&gt;For mer informasjon, se &lt;a href=&quot;https://developer.android.com/guide/topics/data/backup&quot;&gt;Oversikt over sikkerhetskopier&lt;/a&gt; og &lt;a href=&quot;https://support.google.com/android/answer/2819582?hl=no&quot;&gt;Android-sikkerhetskopier&lt;/a&gt;</string>
     <string name="main_restore_message">Skriv inn passord for sikkerhetskopi</string>
     <string name="main_restore_bad_password">Ugyldig passord</string>
     <string name="main_restore_cancel_title">Avbryt gjenoppretting?</string>
@@ -60,7 +56,6 @@
     <string name="password">Passord</string>
     <string name="password_confirm">Bekreft Passord</string>
     <string name="password_info">Sikkerhetskopiering av nøkler lar deg gjenopprette data ved tap og overføre dine nøkler til en ny enhet uten problemer. Sikkerhetskopier er kryptert med passordet nedenfor. Sikkerheten til sikkerhetskopiene avhenger av et sterkt passord. Sikkerhetsmodellen til FreeOTP dikterer at dette passordet IKKE kan endres senere. Vennligst ta dette i betraktning når du velger et passord.</string>
-    <string name="password_weak">Passordet er for svakt!</string>
     <string name="password_match">Passordene stemmer ikke overens!</string>
 
     <!-- Strings for Manual Add activity -->
@@ -93,8 +88,6 @@
     <string name="manual_add_token">Legg Til Nøkkel</string>
     <string name="manual_accessibility_algorithm">Nøkkel-algoritme</string>
     <string name="manual_accessibility_interval">Nøkkel-intervall</string>
-    <string name="manual_invalid_title">Nøkkel er ugyldig!</string>
-    <string name="manual_invalid_message">Nøkkelen du prøver å legge til er ugyldig. Vennligst sjekk at hvert felt følger OTP Key URI-formatet.</string>
     <string name="edit_token">Rediger Nøkkel</string>
     <string name="get_started">KOM IGANG</string>
 
@@ -105,7 +98,6 @@
     <string name="keystore_migration_explanation">FreeOTP-nøkler er nå migrert til Android KeyStore! Dette gir økt sikkerhet for nøkkelhemmeligheter, men nøkkelmaterialet er ikke eksporterbart. \n\nSikkerhetskopi og gjenopprettingsfunksjonalitet er nå lagt til for å sikre at nøkler kan gjenopprettes. Du vil bli bedt om å opprette et hovedpassord for å sette opp kryptert sikkerhetskopi av nøkler.</string>
     <string name="manual_backup_explanation">Alternativt kan en kryptert sikkerhetskopi-datafil eksporteres til ekstern lagring fra appen. Toppverktøylinjen inneholder nå elementer merket \'Sikkerhetskopi\' og \'Gjenopprett\' for å bruke denne manuelle metoden for sikkerhetskopi.</string>
     <string name="google_auto_backup_link">FreeOTP kan delta i Androids automatiske sikkerhetskopiering og gjenopprettingsfunksjonalitet. Denne &lt;a href=&quot;https://support.google.com/android/answer/2819582?hl=no&quot;&gt;Google-linken&lt;/a&gt; inneholder informasjon om hvordan du kan bruke denne metoden for sikkerhetskopi.</string>
-    <string name="hello_blank_fragment">Hei tomt fragment</string>
     <string name="backup_imageview">sikkerhetskopi bildevisning</string>
     <string name="keystore_image">keystore bilde</string>
     <string name="android_keystore_title">Android KeyStore</string>

--- a/mobile/src/main/res/values-zh-rTW/strings.xml
+++ b/mobile/src/main/res/values-zh-rTW/strings.xml
@@ -26,10 +26,8 @@
     <string name="done">完成</string>
     <string name="close">關閉</string>
     <string name="save">儲存</string>
-    <string name="restore">從備份還原</string>
     <string name="about">關於</string>
     <string name="auto_copy_clipboard">自動複製到剪貼簿</string>
-    <string name="manual_add">手動新增</string>
     <string name="cancel">取消</string>
     <string name="delete">刪除</string>
     <string name="move_up">上移</string>
@@ -66,8 +64,6 @@
     <string name="main_invalidated_title">金鑰已失效！</string>
     <string name="main_invalidated_message">此 token 的金鑰已被 Android 金鑰存放區設為失效。這可能是由於您的鎖定螢幕設定的變更。 token 已被移除。請聯絡您的 token 提供者。</string>
     <string name="main_restore_title">從備份還原</string>
-    <string name="main_backup_android_title">Android 備份</string>
-    <string name="main_backup_android_alert">加密的 FreeOTP token 資料包含在由 Android 備份進行的備份和還原操作中。必須啟用 Android 備份以使用此功能。&lt;br/&gt;&lt;br/&gt;欲了解更多資訊，請參閱 &lt;a href=&quot;https://developer.android.com/guide/topics/data/backup&quot;&gt;資料備份概覽&lt;/a&gt; 和 &lt;a href=&quot;https://support.google.com/android/answer/2819582?hl=zh-Hant&quot;&gt;Android 備份&lt;/a&gt;</string>
     <string name="main_restore_message">請輸入備份密碼</string>
     <string name="main_restore_bad_password">密碼無效</string>
     <string name="main_restore_cancel_title">確定取消還原？</string>
@@ -79,7 +75,6 @@
     <string name="password">輸入密碼</string>
     <string name="password_confirm">確認輸入密碼</string>
     <string name="password_info">Token 備份讓您能從資料遺失中復原，並輕易地將您的 token 轉移到新的裝置。\n\n備份會用以下提供的密碼進行加密。您的備份的安全性取決於密碼的強度。\n\nFreeOTP 的安全模型規定此密碼在之後無法變更。在選擇密碼時，請考慮此點。</string>
-    <string name="password_weak">密碼強度太弱！</string>
     <string name="password_match">密碼不一致！</string>
 
 
@@ -113,8 +108,6 @@
     <string name="manual_add_token">新增 token</string>
     <string name="manual_accessibility_algorithm">Token 演算法</string>
     <string name="manual_accessibility_interval">Token 間隔</string>
-    <string name="manual_invalid_title">Token 無效！</string>
-    <string name="manual_invalid_message">您嘗試新增的 token 無效。請檢查每個欄位是否符合 OTP 金鑰 URI 格式。</string>
     <string name="edit_token">編輯 token</string>
     <string name="get_started">開始使用</string>
 
@@ -125,7 +118,6 @@
     <string name="keystore_migration_explanation">FreeOTP token 現已遷移到 Android 金鑰存放區！這讓 token 的安全性增加，但導致 token 的金鑰不可匯出。 \n\n現已新增備份和還原功能以確保 token 可以被恢復。您將被提示建立主密碼以設定加密的 token 備份。</string>
     <string name="manual_backup_explanation">或者，可以從 App 內部將加密的備份資料檔案匯出到外部儲存空間。頂部工具列選單現在包含標籤為「備份」和「還原」的項目，以使用此手動備份方法。</string>
     <string name="google_auto_backup_link">FreeOTP 支援 Android 的自動備份和還原功能。詳細使用此備份方法的資訊，請查閱 &lt;a href=&quot;https://support.google.com/android/answer/2819582?hl=zh-Hant&quot;&gt;Google 提供的說明&lt;/a&gt;。</string>
-    <string name="hello_blank_fragment">Hello blank fragment</string>
     <string name="backup_imageview">備份 imageView</string>
     <string name="keystore_image">金鑰存放區 image</string>
     <string name="android_keystore_title">Android 金鑰存放區</string>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -26,10 +26,8 @@
     <string name="done">Done</string>
     <string name="close">Close</string>
     <string name="save">Save</string>
-    <string name="restore">Restore from Backup</string>
     <string name="about">About</string>
     <string name="auto_copy_clipboard">Auto Clipboard</string>
-    <string name="manual_add">Manual Add</string>
     <string name="cancel">Cancel</string>
     <string name="delete">Delete</string>
     <string name="move_up">Move Up</string>
@@ -66,8 +64,6 @@
     <string name="main_invalidated_title">Key invalidated!</string>
     <string name="main_invalidated_message">The key for this token has been invalidated by the Android Key Store. This may have been due to a change in your lock screen settings. The token has been removed. Please contact your token provider.</string>
     <string name="main_restore_title">Restore from backup</string>
-    <string name="main_backup_android_title">Android Backup</string>
-    <string name="main_backup_android_alert">Encrypted FreeOTP token data is included in backup and restore operations performed by Android Backup. Android Backups must be enabled to take advantage of this feature.&lt;br/&gt;&lt;br/&gt;For more information, see &lt;a href=&quot;https://developer.android.com/guide/topics/data/backup&quot;&gt;Data Backup Overview&lt;/a&gt; and &lt;a href=&quot;https://support.google.com/android/answer/2819582?hl=en&quot;&gt;Android Backups&lt;/a&gt;</string>
     <string name="main_restore_message">Please enter backup password</string>
     <string name="main_restore_bad_password">Invalid password</string>
     <string name="main_restore_cancel_title">Cancel Restore?</string>
@@ -79,7 +75,6 @@
     <string name="password">Password</string>
     <string name="password_confirm">Confirm Password</string>
     <string name="password_info">Token backups allow you to recover from data loss and effortlessly transfer your tokens to a new device.\n\nBackups are encrypted using the password provided below. The security of your backups depends on a strong password.\n\nThe FreeOTP security model dictates this password CANNOT be changed at a later time. Please take this into consideration when choosing a password.</string>
-    <string name="password_weak">Password is too weak!</string>
     <string name="password_match">Passwords do not match!</string>
 
 
@@ -113,8 +108,6 @@
     <string name="manual_add_token">Add Token</string>
     <string name="manual_accessibility_algorithm">Token algorithm</string>
     <string name="manual_accessibility_interval">Token Interval</string>
-    <string name="manual_invalid_title">Token is invalid!</string>
-    <string name="manual_invalid_message">The token you are attempting to add is invalid. Please check that each field is valid following the OTP Key URI Format.</string>
     <string name="edit_token">Edit Token</string>
     <string name="get_started">GET STARTED</string>
 
@@ -125,7 +118,6 @@
     <string name="keystore_migration_explanation">FreeOTP tokens are now migrated into the Android Keystore! This results in increased security of token secrets, however key material is non-exportable. \n\nBackup and restore functionality is now added to ensure tokens can be recovered. You will be prompted to create a master password to setup encrypted token backups.</string>
     <string name="manual_backup_explanation">Alternatively, an encrypted backup data file can be exported to external storage from within the App. The top toolbar menu now contains items labeled \'Backup\' and \'Restore\' to utilize this manual backup method.</string>
     <string name="google_auto_backup_link">FreeOTP can participate in Android automatic backup and restore functionality. This &lt;a href=&quot;https://support.google.com/android/answer/2819582?hl=en&quot;&gt;Google link&lt;/a&gt; contains information on how to utilize this backup method.</string>
-    <string name="hello_blank_fragment">Hello blank fragment</string>
     <string name="backup_imageview">backup imageView</string>
     <string name="keystore_image">keystore image</string>
     <string name="android_keystore_title">Android Keystore</string>


### PR DESCRIPTION
I was working on a french translation for FreeOTP and when searching for the context of several strings, nothing can be found. It seems the dedicated XML files contain legacy strings that are not used anymore.

Hope I didn't break anything. Compilation is still OK and App is starting without any issue. 