### PR TITLE
Several minor changes for UI and extra stuff

### DIFF
--- a/mobile/src/main/java/org/fedorahosted/freeotp/BackupsFragment.java
+++ b/mobile/src/main/java/org/fedorahosted/freeotp/BackupsFragment.java
@@ -16,7 +16,7 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 import android.widget.Button;
 
-public class BackupsFragment extends Fragment implements View.OnClickListener {
+public class BackupsFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
@@ -35,9 +35,5 @@ public class BackupsFragment extends Fragment implements View.OnClickListener {
         SharedPreferences.Editor sharedPreferencesEditor = PreferenceManager.getDefaultSharedPreferences(getContext()).edit();
         sharedPreferencesEditor.putBoolean(COMPLETED_ONBOARDING, true).apply();
         requireActivity().finish();
-    }
-
-    @Override
-    public void onClick(View view) {
     }
 }

--- a/mobile/src/main/java/org/fedorahosted/freeotp/BackupsFragment.java
+++ b/mobile/src/main/java/org/fedorahosted/freeotp/BackupsFragment.java
@@ -4,6 +4,8 @@ import static org.fedorahosted.freeotp.OnBoardingActivity.COMPLETED_ONBOARDING;
 
 import android.content.SharedPreferences;
 import android.os.Bundle;
+
+import androidx.core.text.HtmlCompat;
 import androidx.fragment.app.Fragment;
 
 import android.preference.PreferenceManager;
@@ -21,6 +23,7 @@ public class BackupsFragment extends Fragment implements View.OnClickListener {
         View view = inflater.inflate(R.layout.fragment_backups, container, false);
 
         TextView textView = view.findViewById(R.id.textViewGoogle);
+        textView.setText(HtmlCompat.fromHtml(getString(R.string.google_auto_backup_link), HtmlCompat.FROM_HTML_MODE_LEGACY));
         textView.setMovementMethod(LinkMovementMethod.getInstance());
 
         Button doneButton = view.findViewById(R.id.button_onboard_done);

--- a/mobile/src/main/java/org/fedorahosted/freeotp/main/Activity.java
+++ b/mobile/src/main/java/org/fedorahosted/freeotp/main/Activity.java
@@ -36,7 +36,6 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.security.keystore.KeyPermanentlyInvalidatedException;
 import android.security.keystore.UserNotAuthenticatedException;
-import android.text.Html;
 import android.text.InputType;
 import android.text.SpannableString;
 import android.text.method.LinkMovementMethod;
@@ -83,6 +82,7 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.content.ContextCompat;
+import androidx.core.text.HtmlCompat;
 import androidx.recyclerview.widget.RecyclerView;
 
 public class Activity extends AppCompatActivity
@@ -442,7 +442,7 @@ public class Activity extends AppCompatActivity
                     final AlertDialog dialog = new AlertDialog.Builder(this)
                             .setTitle(r.getString(R.string.main_about_title,
                                     info.versionName, info.versionCode))
-                            .setMessage(Html.fromHtml(r.getString(R.string.main_about_message)))
+                            .setMessage(HtmlCompat.fromHtml(r.getString(R.string.main_about_message), HtmlCompat.FROM_HTML_MODE_LEGACY))
                             .setPositiveButton(R.string.close, null)
                             .create();
 

--- a/mobile/src/main/java/org/fedorahosted/freeotp/main/ViewHolder.java
+++ b/mobile/src/main/java/org/fedorahosted/freeotp/main/ViewHolder.java
@@ -225,6 +225,13 @@ class ViewHolder extends RecyclerView.ViewHolder {
         mImageActive.setOnClickListener(mSelectClick);
         mShare.setOnClickListener(mShareClick);
         mView.setOnClickListener(mViewClick);
+        mView.setOnLongClickListener(new View.OnLongClickListener() {
+            @Override
+            public boolean onLongClick(View v) {
+                mSelectClick.onClick(mIcons);
+                return true;
+            }
+        });
     }
 
 

--- a/mobile/src/main/res/layout/activity_main.xml
+++ b/mobile/src/main/res/layout/activity_main.xml
@@ -62,6 +62,7 @@
         app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
         app:layout_behavior="@string/appbar_scrolling_view_behavior"
         app:spanCount="@integer/columns"
+        tools:listitem="@layout/token"
         />
 
     <LinearLayout

--- a/mobile/src/main/res/layout/activity_manual_add.xml
+++ b/mobile/src/main/res/layout/activity_manual_add.xml
@@ -1,212 +1,209 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_height="match_parent"
     android:layout_width="match_parent"
-    >
-    <LinearLayout xmlns:app="http://schemas.android.com/apk/res-auto"
-        xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    tools:context=".ManualAdd">
+    <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/Base.FreeOTP">
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_height="?android:attr/actionBarSize"
+            android:layout_width="match_parent"
+            android:theme="@style/ToolbarStyle"
+            />
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <ScrollView
         android:layout_height="match_parent"
-        android:orientation="vertical"
-        tools:context=".ManualAdd">
-
-        <com.google.android.material.appbar.AppBarLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:theme="@style/Base.FreeOTP">
-
-            <androidx.appcompat.widget.Toolbar
-                android:id="@+id/toolbar"
-                 android:layout_height="?android:attr/actionBarSize"
-            android:layout_width="match_parent"
-                android:theme="@style/ToolbarStyle"
-                />
-        </com.google.android.material.appbar.AppBarLayout>
-
-        <EditText
-            android:id="@+id/edit_text_account"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:ems="10"
-            android:hint="@string/manual_account_hint"
-            android:inputType="textPersonName"
-            android:minHeight="48dp" />
-
-        <EditText
-            android:id="@+id/edit_text_issuer"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:ems="10"
-            android:hint="@string/manual_issuer_hint"
-            android:inputType="textPersonName"
-            android:minHeight="48dp" />
-
+        android:layout_width="match_parent"
+        >
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <TextView
-                android:id="@+id/text_secret"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:gravity="center"
-                android:text="@string/manual_secret_text"
-                android:textSize="18sp"
-                android:textStyle="bold" />
-
+            android:layout_margin="@dimen/margin"
+            android:orientation="vertical"
+            >
             <EditText
-                android:id="@+id/edit_text_secret"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="2"
+                android:id="@+id/edit_text_account"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
                 android:ems="10"
-                android:hint="@string/manual_secret_base32_text"
+                android:hint="@string/manual_account_hint"
                 android:inputType="textPersonName"
                 android:minHeight="48dp" />
-        </LinearLayout>
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
+            <EditText
+                android:id="@+id/edit_text_issuer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:ems="10"
+                android:hint="@string/manual_issuer_hint"
+                android:inputType="textPersonName"
+                android:minHeight="48dp" />
 
-            <TextView
-                android:id="@+id/text_type"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:gravity="center"
-                android:text="@string/manual_type_text"
-                android:textSize="18sp"
-                android:textStyle="bold" />
-
-            <RadioGroup
-                android:id="@+id/radio_grp_type"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="2"
-                android:checkedButton="@+id/button_hotp"
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
                 android:orientation="horizontal">
 
-                <RadioButton
-                    android:id="@+id/button_totp"
+                <TextView
+                    android:id="@+id/text_secret"
                     android:layout_width="0dp"
-                    android:layout_height="wrap_content"
+                    android:layout_height="match_parent"
                     android:layout_weight="1"
-                    android:text="@string/manual_button_totp_text" />
+                    android:gravity="center"
+                    android:text="@string/manual_secret_text"
+                    android:textSize="18sp"
+                    android:textStyle="bold" />
 
-                <RadioButton
-                    android:id="@+id/button_hotp"
+                <EditText
+                    android:id="@+id/edit_text_secret"
                     android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="@string/manual_button_hotp_text" />
-            </RadioGroup>
-        </LinearLayout>
+                    android:layout_height="match_parent"
+                    android:layout_weight="2"
+                    android:ems="10"
+                    android:hint="@string/manual_secret_base32_text"
+                    android:inputType="textPersonName"
+                    android:minHeight="48dp" />
+            </LinearLayout>
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <TextView
-                android:id="@+id/text_digits"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:gravity="center"
-                android:text="@string/manual_digits_text"
-                android:textSize="18sp"
-                android:textStyle="bold" />
-
-            <RadioGroup
-                android:id="@+id/radio_grp_digits"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="2"
-                android:checkedButton="@+id/button_six"
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
                 android:orientation="horizontal">
 
-                <RadioButton
-                    android:id="@+id/button_six"
+                <TextView
+                    android:id="@+id/text_type"
                     android:layout_width="0dp"
-                    android:layout_height="wrap_content"
+                    android:layout_height="match_parent"
                     android:layout_weight="1"
-                    android:text="@string/manual_button_digits_six" />
+                    android:gravity="center"
+                    android:text="@string/manual_type_text"
+                    android:textSize="18sp"
+                    android:textStyle="bold" />
 
-                <RadioButton
-                    android:id="@+id/button_eight"
+                <RadioGroup
+                    android:id="@+id/radio_grp_type"
                     android:layout_width="0dp"
-                    android:layout_height="wrap_content"
+                    android:layout_height="match_parent"
+                    android:layout_weight="2"
+                    android:checkedButton="@+id/button_hotp"
+                    android:orientation="horizontal">
+
+                    <RadioButton
+                        android:id="@+id/button_totp"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/manual_button_totp_text" />
+
+                    <RadioButton
+                        android:id="@+id/button_hotp"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/manual_button_hotp_text" />
+                </RadioGroup>
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/text_digits"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
                     android:layout_weight="1"
-                    android:text="@string/manual_button_digits_eight" />
-            </RadioGroup>
-        </LinearLayout>
+                    android:gravity="center"
+                    android:text="@string/manual_digits_text"
+                    android:textSize="18sp"
+                    android:textStyle="bold" />
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
+                <RadioGroup
+                    android:id="@+id/radio_grp_digits"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="2"
+                    android:checkedButton="@+id/button_six"
+                    android:orientation="horizontal">
 
-            <TextView
-                android:id="@+id/text_algorithm"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:gravity="center"
-                android:text="@string/manual_algorithm"
-                android:textSize="18sp"
-                android:textStyle="bold" />
+                    <RadioButton
+                        android:id="@+id/button_six"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/manual_button_digits_six" />
 
-            <Spinner
-                android:id="@+id/spinner_algorithms"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="2"
-                android:contentDescription="@string/manual_accessibility_algorithm"
-                android:minHeight="48dp" />
-        </LinearLayout>
+                    <RadioButton
+                        android:id="@+id/button_eight"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/manual_button_digits_eight" />
+                </RadioGroup>
+            </LinearLayout>
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
 
-            <TextView
-                android:id="@+id/text_interval"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:gravity="center"
-                android:text="@string/manual_interval"
-                android:textSize="18sp"
-                android:textStyle="bold" />
+                <TextView
+                    android:id="@+id/text_algorithm"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:gravity="center"
+                    android:text="@string/manual_algorithm"
+                    android:textSize="18sp"
+                    android:textStyle="bold" />
 
-            <Spinner
-                android:id="@+id/spinner_intervals"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="2"
-                android:contentDescription="@string/manual_accessibility_interval"
-                android:minHeight="48dp" />
-        </LinearLayout>
+                <Spinner
+                    android:id="@+id/spinner_algorithms"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="2"
+                    android:contentDescription="@string/manual_accessibility_algorithm"
+                    android:minHeight="48dp" />
+            </LinearLayout>
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/text_interval"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:gravity="center"
+                    android:text="@string/manual_interval"
+                    android:textSize="18sp"
+                    android:textStyle="bold" />
+
+                <Spinner
+                    android:id="@+id/spinner_intervals"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="2"
+                    android:contentDescription="@string/manual_accessibility_interval"
+                    android:minHeight="48dp" />
+            </LinearLayout>
 
             <Button
                 android:id="@+id/button_add"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
                 android:onClick="addToken"
-                android:text="@string/manual_add_token"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-    </LinearLayout>
-</ScrollView>
+                android:text="@string/manual_add_token" />
+        </LinearLayout>
+    </ScrollView>
+</LinearLayout>

--- a/mobile/src/main/res/layout/activity_password.xml
+++ b/mobile/src/main/res/layout/activity_password.xml
@@ -35,88 +35,88 @@
             />
     </com.google.android.material.appbar.AppBarLayout>
 
-    <LinearLayout
-        android:layout_width="match_parent"
+    <ScrollView
         android:layout_height="match_parent"
-        android:orientation="vertical"
-        android:layout_margin="@dimen/margin">
-        <androidx.appcompat.widget.AppCompatTextView
-            android:text="@string/password_info"
-            android:id="@+id/info"
-
+        android:layout_width="match_parent"
+        >
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_width="match_parent"
-            />
+            android:orientation="vertical"
+            android:layout_margin="@dimen/margin">
+            <androidx.appcompat.widget.AppCompatTextView
+                android:text="@string/password_info"
+                android:id="@+id/info"
 
-        <FrameLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+                android:layout_height="wrap_content"
+                android:layout_width="match_parent"
+                />
+
+            <FrameLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+                <com.google.android.material.textfield.TextInputLayout
+                    style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox"
+                    android:id="@+id/password_layout"
+                    app:endIconMode="password_toggle"
+                    app:hintAnimationEnabled="true"
+                    app:errorEnabled="true"
+                    android:hint="@string/password"
+
+                    android:layout_marginTop="@dimen/margin"
+                    android:layout_height="wrap_content"
+                    android:layout_width="match_parent"
+                    >
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:layout_height="wrap_content"
+                        android:layout_width="match_parent"
+                        android:inputType="textPassword"
+                        android:id="@+id/password"
+                        />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <ProgressBar
+                    android:layout_width="16dp"
+                    android:layout_height="16dp"
+                    android:layout_marginBottom="36dp"
+                    android:layout_marginEnd="18dp"
+                    android:layout_gravity="bottom|end"
+
+                    android:visibility="invisible"
+                    android:id="@+id/progress"
+                    />
+            </FrameLayout>
+
             <com.google.android.material.textfield.TextInputLayout
                 style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox"
-                android:id="@+id/password_layout"
                 app:endIconMode="password_toggle"
                 app:hintAnimationEnabled="true"
                 app:errorEnabled="true"
-                android:hint="@string/password"
 
-                android:layout_marginTop="@dimen/margin"
+                android:id="@+id/confirm_layout"
+                android:hint="@string/password_confirm"
+                android:visibility="invisible"
+                tools:visibility="visible"
+
                 android:layout_height="wrap_content"
-                android:layout_width="match_parent"
-                >
+                android:layout_width="match_parent">
 
                 <com.google.android.material.textfield.TextInputEditText
-                    android:layout_height="wrap_content"
                     android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
                     android:inputType="textPassword"
-                    android:id="@+id/password"
+                    android:id="@+id/confirm"
                     />
             </com.google.android.material.textfield.TextInputLayout>
 
-            <ProgressBar
-                android:layout_width="16dp"
-                android:layout_height="16dp"
-                android:layout_marginBottom="36dp"
-                android:layout_marginEnd="18dp"
-                android:layout_gravity="bottom|end"
-
-                android:visibility="invisible"
-                android:id="@+id/progress"
-                />
-        </FrameLayout>
-
-        <com.google.android.material.textfield.TextInputLayout
-            style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox"
-            app:endIconMode="password_toggle"
-            app:hintAnimationEnabled="true"
-            app:errorEnabled="true"
-
-            android:id="@+id/confirm_layout"
-            android:hint="@string/password_confirm"
-            android:visibility="invisible"
-
-            android:layout_height="wrap_content"
-            android:layout_width="match_parent">
-
-            <com.google.android.material.textfield.TextInputEditText
+            <com.google.android.material.button.MaterialButton
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:inputType="textPassword"
-                android:id="@+id/confirm"
-                />
-        </com.google.android.material.textfield.TextInputLayout>
-
-        <FrameLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent">
-            <com.google.android.material.button.MaterialButton
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="bottom|end"
-
                 android:enabled="false"
                 android:id="@+id/done"
                 android:text="@string/done"
                 />
-        </FrameLayout>
-    </LinearLayout>
+        </LinearLayout>
+    </ScrollView>
 </LinearLayout>

--- a/mobile/src/main/res/layout/fragment_backups.xml
+++ b/mobile/src/main/res/layout/fragment_backups.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    >
 
     <ImageView
         android:id="@+id/imageView"
@@ -37,7 +39,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
         app:layout_constraintWidth_percent=".80"
-        android:text="@string/google_auto_backup_link"
+        tools:text="@string/google_auto_backup_link"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toBottomOf="@id/textViewTitle" />

--- a/mobile/src/main/res/layout/fragment_welcome.xml
+++ b/mobile/src/main/res/layout/fragment_welcome.xml
@@ -21,7 +21,7 @@
         android:id="@+id/textViewTitle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Welcome to FreeOTP 2.0"
+        android:text="@string/app_welcome"
         android:textSize="26dp"
         android:layout_marginTop="24dp"
         app:layout_constraintLeft_toLeftOf="parent"

--- a/mobile/src/main/res/values-fr/strings.xml
+++ b/mobile/src/main/res/values-fr/strings.xml
@@ -20,6 +20,7 @@
 
 <resources>
     <string name="app_name">FreeOTP</string>
+    <string name="app_welcome">Bienvenue dans FreeOTP 2.0</string>
 
     <!-- Buttons -->
     <string name="ok">Ok</string>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
 
 <resources>
     <string name="app_name">FreeOTP</string>
+    <string name="app_welcome">Welcome to FreeOTP 2.0</string>
 
     <!-- Buttons -->
     <string name="ok">Ok</string>


### PR DESCRIPTION
Hi,
I would like to propose some modifications to the application.

1. Replacement hardcoded welcome string displayed on the welcome fragment with a translatable one added to XML string resource file. By the way, add a French translation.
2. Simply use `tools:listitem` in main activity RecyclerView to preview the screen in Android Studio with item layout.
3. Add margins / padding to manual add activity layout. I have also moved away the Toolbar from ScrollView to follow the behavior from main activity layout. 
Speaking of Toolbars, anybody know why they are nested in [AppBarLayouts](https://developer.android.com/reference/com/google/android/material/appbar/AppBarLayout)? I understand it could be interesting to add scrolling gestures but I can't see where such a feature is used in the FreeOTP application.
4. Nest password activity layout in a ScrollView. It should fix issue #349.
5. Add a long click listener on item to select it, the same way clicking on image does. It addresses part of issue #278.
6. Fix hyperlink not well displayed in backup fragment.
7. Minor stuff.

Let me know if you want me to split these commits in several PRs instead.
Thanks.
