### PR TITLE
CI: Update tests workflow java to 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,10 @@ jobs:
     - name: Checkout project sources
       uses: actions/checkout@v3
 
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: 11
+        java-version: 17
         distribution: 'adopt'
         cache: 'gradle'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,9 @@ jobs:
       run: ./gradlew build -x lint
 
   tests:
-    runs-on: macos-latest
+    # macOS v14 / m1 GitHub Actions runners not allowing Android emulators
+    # https://github.com/ReactiveCircus/android-emulator-runner/issues/397
+    runs-on: macos-13
     steps:
     - name: Checkout project sources
       uses: actions/checkout@v3


### PR DESCRIPTION
Address CI error in running tests

java.lang.UnsupportedClassVersionError: com/android/sdklib/tool/sdkmanager/SdkManagerCli has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0