### PR TITLE
Move margin from inner LinearLayout to ScrollView to fix cut-off content

### DIFF
--- a/mobile/src/main/res/layout/activity_manual_add.xml
+++ b/mobile/src/main/res/layout/activity_manual_add.xml
@@ -21,11 +21,11 @@
     <ScrollView
         android:layout_height="match_parent"
         android:layout_width="match_parent"
+        android:layout_margin="@dimen/margin"
         >
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_margin="@dimen/margin"
             android:orientation="vertical"
             >
             <EditText

--- a/mobile/src/main/res/layout/activity_password.xml
+++ b/mobile/src/main/res/layout/activity_password.xml
@@ -38,16 +38,15 @@
     <ScrollView
         android:layout_height="match_parent"
         android:layout_width="match_parent"
+        android:layout_margin="@dimen/margin"
         >
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:layout_margin="@dimen/margin">
+            android:orientation="vertical">
             <androidx.appcompat.widget.AppCompatTextView
                 android:text="@string/password_info"
                 android:id="@+id/info"
-
                 android:layout_height="wrap_content"
                 android:layout_width="match_parent"
                 />


### PR DESCRIPTION
It affects Password and Manual add activities.

Tested in Android Studio Layout Preview for a small factor phone (320x427dp). It should fix issue reported by @sphh in issue #349.