### PR TITLE
Remove Travis CI config and update README badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: android
-dist: trusty
-android:
-  components:
-    - tools
-    - platform-tools
-    - build-tools-29.0.2
-    - android-29
-    - extra-google-m2repository

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/freeotp/freeotp-android.svg?branch=master)](https://travis-ci.org/freeotp/freeotp-android)
+[![Build Status](https://github.com/freeotp/freeotp-android/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/freeotp/freeotp-android/actions/workflows/build.yml)
 
 # FreeOTP
 


### PR DESCRIPTION
Close #342

Migrate from Travis CI to GitHub Actions.

* Remove the Travis CI badge and link from `README.md`.
* Add a GitHub Actions badge and link to `README.md`.
* Delete the `.travis.yml` file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/freeotp/freeotp-android/issues/342?shareId=51192598-1fe4-4520-ac7d-9379820b69d6).