### PR TITLE
Fixbug: In manual_add activity: incorrect type field input cause i18n

### DIFF
--- a/mobile/src/main/java/org/fedorahosted/freeotp/ManualAdd.java
+++ b/mobile/src/main/java/org/fedorahosted/freeotp/ManualAdd.java
@@ -86,7 +86,18 @@ public class ManualAdd extends AppCompatActivity {
 
     private Uri makeUri() {
         String label = String.format("%s:%s", mIssuer.getText(), mAccount.getText());
-        String type = mType.getText().toString().toLowerCase();
+        // cause i18n，this text may not TOTP OR HOTP
+        String type;
+        switch(mType.getId()) {
+            case R.id.button_totp:
+                type = "totp";
+                break;
+            case R.id.button_hotp:
+                type = "hotp";
+                break;
+            default:
+                type = "";
+        } 
 
         // Validate URI first or Activity will crash
         Uri.Builder builder = new Uri.Builder();


### PR DESCRIPTION
Fix incorrect type field input in manual_add activity when using Chinese

When using Chinese input, the type field in manual_add activity was incorrectly processed.
This PR fixes the encoding and validation logic to handle Chinese input properly.

![about_whats_wrong](https://github.com/user-attachments/assets/885b00cf-4a63-43c0-81d7-9939637925a8)
