### PR TITLE
Remove unmaintained Fotoapparat module and other updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.5.0'
+        classpath 'com.android.tools.build:gradle:8.9.2'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.5.0'
@@ -13,11 +13,8 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven { url 'https://jitpack.io' }
-        // Android studio requires google m2 to obtain support libraries, even though
-        // we are not directly referencing them at present.
-        google()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -40,7 +40,6 @@ dependencies {
     implementation 'com.google.android.material:material:1.12.0'
     implementation 'com.squareup.picasso:picasso:2.71828'
     implementation 'commons-codec:commons-codec:1.15'
-    implementation 'io.fotoapparat:fotoapparat:2.7.0'
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'com.google.zxing:core:3.3.3'
     implementation 'me.gosimple:nbvcxz:1.4.2'
@@ -52,4 +51,10 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+
+    // CameraX
+    implementation "androidx.camera:camera-core:1.4.2"
+    implementation "androidx.camera:camera-camera2:1.4.2"
+    implementation "androidx.camera:camera-lifecycle:1.4.2"
+    implementation "androidx.camera:camera-view:1.4.2"
 }

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation 'com.google.zxing:core:3.3.3'
     implementation 'me.gosimple:nbvcxz:1.4.2'
     implementation 'androidx.appcompat:appcompat:1.7.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.2.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.9.0'
     androidTestImplementation 'org.mockito:mockito-android:3.9.0'

--- a/mobile/src/main/java/org/fedorahosted/freeotp/main/ScanDialogFragment.java
+++ b/mobile/src/main/java/org/fedorahosted/freeotp/main/ScanDialogFragment.java
@@ -113,7 +113,7 @@ public class ScanDialogFragment extends AppCompatDialogFragment implements Image
     public void onStart() {
         super.onStart();
 
-        switch (ContextCompat.checkSelfPermission(getContext(), Manifest.permission.CAMERA)) {
+        switch (ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.CAMERA)) {
             case PackageManager.PERMISSION_GRANTED:
                 onRequestPermissionsResult(0,
                         new String[] { Manifest.permission.CAMERA },
@@ -278,7 +278,7 @@ public class ScanDialogFragment extends AppCompatDialogFragment implements Image
                                 mImage.post(new Runnable() {
                                     @Override
                                     public void run() {
-                                        Activity a = (Activity) getActivity();
+                                        Activity a = (Activity) requireActivity();
                                         a.addToken(Uri.parse(uri), true);
                                     }
                                 });

--- a/mobile/src/main/java/org/fedorahosted/freeotp/main/ScanDialogFragment.java
+++ b/mobile/src/main/java/org/fedorahosted/freeotp/main/ScanDialogFragment.java
@@ -91,10 +91,9 @@ public class ScanDialogFragment extends AppCompatDialogFragment implements Image
 
     public static boolean hasCamera(Context context) {
         PackageManager pm = context.getPackageManager();
-        return pm.hasSystemFeature(PackageManager.FEATURE_CAMERA);
+        return pm.hasSystemFeature(PackageManager.FEATURE_CAMERA_ANY);
     }
 
-    @SuppressWarnings("unchecked")
     @Nullable
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,

--- a/mobile/src/main/java/org/fedorahosted/freeotp/main/ScanDialogFragment.java
+++ b/mobile/src/main/java/org/fedorahosted/freeotp/main/ScanDialogFragment.java
@@ -256,36 +256,27 @@ public class ScanDialogFragment extends AppCompatDialogFragment implements Image
 
             vibrate();
 
-            mImage.post(new Runnable() {
-                @Override
-                public void run() {
-                    mProgress.setVisibility(View.INVISIBLE);
-                    mCamera.animate()
-                        .setInterpolator(new DecelerateInterpolator())
-                        .setDuration(2000)
-                        .alpha(0.0f)
-                        .start();
+            mImage.post(() -> {
+                mProgress.setVisibility(View.INVISIBLE);
+                mCamera.animate()
+                    .setInterpolator(new DecelerateInterpolator())
+                    .setDuration(2000)
+                    .alpha(0.0f)
+                    .start();
 
-                    mImage.setImageBitmap(b);
-                    mImage.animate()
-                        .setInterpolator(new DecelerateInterpolator())
-                        .setDuration(2000)
-                        .alpha(1.0f)
-                        .withEndAction(new Runnable() {
-                            @Override
-                            public void run() {
-                                mImage.post(new Runnable() {
-                                    @Override
-                                    public void run() {
-                                        Activity a = (Activity) requireActivity();
-                                        a.addToken(Uri.parse(uri), true);
-                                    }
-                                });
-                                dismiss();
-                            }
-                        })
-                        .start();
-                }
+                mImage.setImageBitmap(b);
+                mImage.animate()
+                    .setInterpolator(new DecelerateInterpolator())
+                    .setDuration(2000)
+                    .alpha(1.0f)
+                    .withEndAction(() -> {
+                        mImage.post(() -> {
+                            Activity a = (Activity) requireActivity();
+                            a.addToken(Uri.parse(uri), true);
+                        });
+                        dismiss();
+                    })
+                    .start();
             });
         } catch (NotFoundException | ChecksumException | FormatException | WriterException e) {
             Log.e(LOGTAG, "Exception", e);

--- a/mobile/src/main/res/layout/fragment_scan.xml
+++ b/mobile/src/main/res/layout/fragment_scan.xml
@@ -23,12 +23,14 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:background="@android:color/black">
-    <io.fotoapparat.view.CameraView
-        android:layout_height="match_parent"
+
+    <androidx.camera.view.PreviewView
         android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:id="@+id/camera"
-        android:alpha="0.0"
+        android:layout_gravity="center"
         />
 
     <ImageView


### PR DESCRIPTION
Unfortunately, Fotoapparat dependency seems to be unmaintained. It looks
more reliable to migrate to CameraX from Android Jetpack.

Removing Fotoapparat allows to remove obsolete JCenter artifact repository.

By the way, also upgrade Android Gradle Plugin to 8.9.2 as proposed in Android Studio.