### PR TITLE
Move target SDK to 35

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -17,6 +17,9 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+        debug {
+            applicationIdSuffix ".debug"
+        }
     }
     testOptions {
         unitTests.all {

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdk 34
+    compileSdk 35
     namespace 'org.fedorahosted.freeotp'
     defaultConfig {
         applicationId "org.fedorahosted.freeotp"
         minSdkVersion 23
-        targetSdkVersion 34
+        targetSdkVersion 35
         versionCode 46
         versionName "2.0.5"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -41,15 +41,13 @@
         <activity
             android:name=".ManualAdd"
             android:exported="false"
-            android:parentActivityName=".main.Activity"
-            android:theme="@style/FreeOTP.Purple.NoActionBar" />
+            android:parentActivityName=".main.Activity" />
         <activity
             android:name=".main.Activity"
             android:configChanges="orientation|screenSize"
             android:exported="true"
             android:label="@string/app_name"
-            android:launchMode="singleTask"
-            android:theme="@style/FreeOTP.Purple.NoActionBar">
+            android:launchMode="singleTask">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -69,8 +67,7 @@
             android:configChanges="orientation|screenSize"
             android:exported="true"
             android:label="@string/app_name"
-            android:launchMode="singleTask"
-            android:theme="@style/FreeOTP.Purple.NoActionBar">
+            android:launchMode="singleTask">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/mobile/src/main/res/values-night/styles.xml
+++ b/mobile/src/main/res/values-night/styles.xml
@@ -19,19 +19,8 @@
    - limitations under the License.
    -->
 <resources>
-    <style name="FreeOTP.Purple.NoActionBar" parent="FreeOTP.Purple">
-        <item name="windowActionBar">false</item>
-        <item name="windowNoTitle">true</item>
-    </style>
-    <attr name="buttoncolor" format="reference"/>
-
-    <!-- Toolbar styles -->
-    <style name="ToolbarStyle" parent="ThemeOverlay.AppCompat.ActionBar">
+    <!-- Overrides for dark mode -->
+    <style name="PopupMenuStyle" parent="android:Widget.Holo.Light.PopupMenu">
         <item name="android:textColorPrimary">@color/white</item>
     </style>
-
-    <style name="PopupMenuStyle" parent="android:Widget.Holo.Light.PopupMenu">
-    <item name="android:textColorPrimary">@color/white</item>
-    </style>
-
 </resources>

--- a/mobile/src/main/res/values-night/themes.xml
+++ b/mobile/src/main/res/values-night/themes.xml
@@ -1,19 +1,11 @@
-<resources xmlns:tools="http://schemas.android.com/tools">
-    <style name="Base.FreeOTP" parent="@style/Theme.MaterialComponents.DayNight.NoActionBar">
-    </style>
-
-    <style name="FreeOTP" parent="@style/Base.FreeOTP"/>
-
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Overrides for dark mode -->
     <style name="FreeOTP.Purple">
         <item name="colorPrimary">@color/purple_500</item>
         <item name="colorSecondary">@color/purple_500</item>
         <item name="colorPrimaryVariant">@color/freeotp_grey_dark_primary</item>
         <item name="colorPrimaryDark">@color/dark_grey</item>
         <item name="buttoncolor">@drawable/buttoncolor</item>
-    </style>
-
-    <style name="FreeOTP.NoActionBar">
-        <item name="windowActionBar">false</item>
-        <item name="windowNoTitle">true</item>
     </style>
 </resources>

--- a/mobile/src/main/res/values-v35/styles.xml
+++ b/mobile/src/main/res/values-v35/styles.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<resources>
+    <style name="FreeOTP.OptOutEdgeToEdgeEnforcement" parent="FreeOTP.Purple">
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    </style>
+</resources>

--- a/mobile/src/main/res/values/styles.xml
+++ b/mobile/src/main/res/values/styles.xml
@@ -20,7 +20,10 @@
    -->
 
 <resources>
-    <style name="FreeOTP.Purple.NoActionBar" parent="FreeOTP.Purple">
+    <style name="FreeOTP.OptOutEdgeToEdgeEnforcement" parent="FreeOTP.Purple">
+    </style>
+
+    <style name="FreeOTP.Purple.NoActionBar" parent="FreeOTP.OptOutEdgeToEdgeEnforcement">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
     </style>

--- a/mobile/src/main/res/values/styles.xml
+++ b/mobile/src/main/res/values/styles.xml
@@ -28,12 +28,11 @@
 
     <!-- Toolbar styles -->
     <style name="ToolbarStyle" parent="ThemeOverlay.AppCompat.ActionBar">
-        <item name="android:textColorPrimary">#fff</item>
+        <item name="android:textColorPrimary">@color/white</item>
     </style>
 
     <style name="PopupMenuStyle" parent="android:Widget.Holo.Light.PopupMenu">
         <item name="android:popupBackground">@android:color/white</item>
         <item name="android:textColorPrimary">@color/black</item>
-
     </style>
 </resources>

--- a/mobile/src/main/res/values/themes.xml
+++ b/mobile/src/main/res/values/themes.xml
@@ -1,5 +1,6 @@
-<resources xmlns:tools="http://schemas.android.com/tools">
-    <!-- Base application theme. -->
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Base application theme -->
     <style name="Base.FreeOTP" parent="@style/Theme.MaterialComponents.DayNight.NoActionBar">
     </style>
 


### PR DESCRIPTION
Android target SDK 35 is last requirement for app submissions on Google Play Store with deadline set to August, 31 2025.
Apart from edge to edge design (opted-out for now), the changes does not seem to affect FreeOTP.
