### PR TITLE
Enable app language preference for Android 13+

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -39,6 +39,9 @@ android {
     buildFeatures {
         viewBinding true
     }
+    androidResources {
+        generateLocaleConfig true
+    }
 }
 
 dependencies {

--- a/mobile/src/main/res/resources.properties
+++ b/mobile/src/main/res/resources.properties
@@ -1,0 +1,2 @@
+# Default locale
+unqualifiedResLocale=en


### PR DESCRIPTION
Inspired by issue #442 by @Patriccollu.
However, this is only the (easy) solution for Android 13+. To enable it for lower versions of Android, an in-app language picker must be added. It certainly applies to create a dedicated settings screen and could be done in a future PR.

---

Managed in Android app settings. Simply use AGP setting to enable it.
Check https://developer.android.com/guide/topics/resources/app-languages for details.