### PR TITLE
Support inverted QR code

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation 'com.squareup.picasso:picasso:2.71828'
     implementation 'commons-codec:commons-codec:1.15'
     implementation 'com.google.code.gson:gson:2.10.1'
-    implementation 'com.google.zxing:core:3.3.3'
+    implementation 'com.google.zxing:core:3.5.3'
     implementation 'me.gosimple:nbvcxz:1.4.2'
     implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'

--- a/mobile/src/main/java/org/fedorahosted/freeotp/main/ScanDialogFragment.java
+++ b/mobile/src/main/java/org/fedorahosted/freeotp/main/ScanDialogFragment.java
@@ -48,15 +48,14 @@ import android.widget.TextView;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.zxing.BarcodeFormat;
 import com.google.zxing.BinaryBitmap;
-import com.google.zxing.ChecksumException;
-import com.google.zxing.FormatException;
+import com.google.zxing.DecodeHintType;
 import com.google.zxing.LuminanceSource;
+import com.google.zxing.MultiFormatReader;
 import com.google.zxing.NotFoundException;
 import com.google.zxing.PlanarYUVLuminanceSource;
 import com.google.zxing.WriterException;
 import com.google.zxing.common.BitMatrix;
 import com.google.zxing.common.HybridBinarizer;
-import com.google.zxing.qrcode.QRCodeReader;
 import com.google.zxing.qrcode.QRCodeWriter;
 
 import org.fedorahosted.freeotp.R;
@@ -74,6 +73,8 @@ import androidx.camera.view.PreviewView;
 import androidx.core.content.ContextCompat;
 
 import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -237,8 +238,13 @@ public class ScanDialogFragment extends AppCompatDialogFragment implements Image
         LuminanceSource ls = getLuminanceSource(imageProxy);
 
         try {
-            BinaryBitmap bb = new BinaryBitmap(new HybridBinarizer(ls));
-            final String uri = new QRCodeReader().decode(bb).getText();
+            final BinaryBitmap bb = new BinaryBitmap(new HybridBinarizer(ls));
+            final List<BarcodeFormat> formats = List.of(BarcodeFormat.QR_CODE);
+            final Map<DecodeHintType,?> hints = Map.of(
+                    DecodeHintType.POSSIBLE_FORMATS, formats,
+                    DecodeHintType.ALSO_INVERTED, Boolean.TRUE
+            );
+            final String uri = new MultiFormatReader().decode(bb, hints).getText();
 
             int size = mImage.getWidth();
             if (size > mImage.getHeight())
@@ -278,7 +284,7 @@ public class ScanDialogFragment extends AppCompatDialogFragment implements Image
                     })
                     .start();
             });
-        } catch (NotFoundException | ChecksumException | FormatException | WriterException e) {
+        } catch (NotFoundException | WriterException e) {
             Log.e(LOGTAG, "Exception", e);
         }
 


### PR DESCRIPTION
First update ZXing library to last version (3.5.3) to benefit from new option allowing to check for normal and inverted bitmap source. See https://github.com/zxing/zxing/pull/1371

To be able to use this new option, use MultiFormatReader instead of QRCodeReader but restrict to QR code format only.

---

It should fix issues #434, #447.
I have also made a dirty WIP of FreeOTP generator to generate inverted QR code [here](https://github.com/joggee-fr/freeotp.github.io/tree/jg/invert). 