### PR TITLE
fix(ScanDialogFragment): improve the lens/camera selection preference order

### DIFF
--- a/mobile/src/main/java/org/fedorahosted/freeotp/main/ScanDialogFragment.java
+++ b/mobile/src/main/java/org/fedorahosted/freeotp/main/ScanDialogFragment.java
@@ -134,14 +134,14 @@ public class ScanDialogFragment extends AppCompatDialogFragment implements Image
             return CameraSelector.LENS_FACING_BACK;
         }
 
+        if (cameraProvider.hasCamera(CameraSelector.DEFAULT_FRONT_CAMERA)) {
+            return CameraSelector.LENS_FACING_FRONT;
+        }
+
         CameraSelector externalCameraSelector = new CameraSelector.Builder()
             .requireLensFacing(CameraSelector.LENS_FACING_EXTERNAL).build();
         if (cameraProvider.hasCamera(externalCameraSelector)) {
             return CameraSelector.LENS_FACING_EXTERNAL;
-        }
-
-        if (cameraProvider.hasCamera(CameraSelector.DEFAULT_FRONT_CAMERA)) {
-            return CameraSelector.LENS_FACING_FRONT;
         }
 
         throw new RuntimeException("Can't retrieve camera lens facing");


### PR DESCRIPTION
Changes the camera selection preference order like this:
RearCam -> FrontCam -> ExternalCam

Refs: https://github.com/freeotp/freeotp-android/issues/450

Tested on Virtual Android Device with the following config (stripped other properties for brevity)
```
Properties
avd.ini.displayname              No Rear Cam Phone - API 36.1
AvdId                            No_Rear_Cam_Phone_-_API_36.1

hw.camera.back                   none
hw.camera.front                  webcam0

hw.device.manufacturer           Generic
hw.device.name                   medium_phone
target                           android-36.1
```