### PR TITLE
Use string resources for manual token toasts

### DIFF
--- a/mobile/src/main/java/org/fedorahosted/freeotp/ManualAdd.java
+++ b/mobile/src/main/java/org/fedorahosted/freeotp/ManualAdd.java
@@ -1,13 +1,9 @@
 package org.fedorahosted.freeotp;
 
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.Toolbar;
-
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.text.TextUtils;
-import android.util.Log;
 import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.EditText;
@@ -17,7 +13,10 @@ import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import org.apache.commons.codec.binary.StringUtils;
+import androidx.annotation.StringRes;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+
 import org.fedorahosted.freeotp.main.Activity;
 
 public class ManualAdd extends AppCompatActivity {
@@ -97,7 +96,7 @@ public class ManualAdd extends AppCompatActivity {
                 break;
             default:
                 type = "";
-        } 
+        }
 
         // Validate URI first or Activity will crash
         Uri.Builder builder = new Uri.Builder();
@@ -119,21 +118,16 @@ public class ManualAdd extends AppCompatActivity {
         String secret = mSecret.getText().toString();
         String issuer = mIssuer.getText().toString();
         String account = mAccount.getText().toString();
-        Boolean valid = true;
-        String msg = "";
+        @StringRes int msgId = 0;
 
         if (TextUtils.isEmpty(secret)) {
-            msg = "Secret must not be empty";
-            valid = false;
+            msgId = R.string.manual_empty_secret;
+        } else if (issuer.contains(":") || account.contains(":")) {
+            msgId = R.string.manual_malformed_issuer_account;
         }
 
-        if(issuer.contains(":") || account.contains(":")) {
-            msg = "Issuer and account may not contain \":\"";
-            valid = false;
-        }
-
-        if (!valid) {
-            Toast.makeText(getApplicationContext(), msg,Toast.LENGTH_SHORT).show();
+        if (msgId != 0) {
+            Toast.makeText(getApplicationContext(), getString(msgId),Toast.LENGTH_SHORT).show();
             return false;
         } else {
             return true;
@@ -144,6 +138,7 @@ public class ManualAdd extends AppCompatActivity {
         if (!inputValid()) {
             return;
         }
+
         getSelected();
         Uri uri = makeUri();
 

--- a/mobile/src/main/res/values-fr/strings.xml
+++ b/mobile/src/main/res/values-fr/strings.xml
@@ -108,6 +108,9 @@
     <string name="manual_add_token">Ajouter un jeton</string>
     <string name="manual_accessibility_algorithm">Algorithme des jetons</string>
     <string name="manual_accessibility_interval">Intervalle des jetons</string>
+    <string name="manual_empty_secret">Le secret ne doit pas être vide</string>
+    <string name="manual_malformed_issuer_account">Le fournisseur et le compte ne peuvent contenir ":"</string>
+
     <string name="edit_token">Éditer le jeton</string>
     <string name="get_started">COMMENCER</string>
 

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -78,7 +78,6 @@
     <string name="password_info">Token backups allow you to recover from data loss and effortlessly transfer your tokens to a new device.\n\nBackups are encrypted using the password provided below. The security of your backups depends on a strong password.\n\nThe FreeOTP security model dictates this password CANNOT be changed at a later time. Please take this into consideration when choosing a password.</string>
     <string name="password_match">Passwords do not match!</string>
 
-
     <!-- Strings for Manual Add activity -->
     <string-array name="algorithms_array">
         <item>SHA1</item>
@@ -109,6 +108,9 @@
     <string name="manual_add_token">Add Token</string>
     <string name="manual_accessibility_algorithm">Token algorithm</string>
     <string name="manual_accessibility_interval">Token Interval</string>
+    <string name="manual_empty_secret">Secret must not be empty</string>
+    <string name="manual_malformed_issuer_account">Issuer and account may not contain ":"</string>
+
     <string name="edit_token">Edit Token</string>
     <string name="get_started">GET STARTED</string>
 


### PR DESCRIPTION
Use string resources instead of hardcoded english string for toasts in manual token add screen when error has been detected in input parameters.

Add by the way, French translations for these messages.