### PR TITLE
Fixes #452

### DIFF
--- a/mobile/src/main/java/org/fedorahosted/freeotp/main/Adapter.java
+++ b/mobile/src/main/java/org/fedorahosted/freeotp/main/Adapter.java
@@ -289,12 +289,12 @@ public class Adapter extends SelectableAdapter<ViewHolder> implements ViewHolder
             Token token = null;
             if (stored != null) {
                 token = Token.deserialize(stored);
+                if (token == null) {
+                    Log.e(LOGTAG, "Token is null");
+                    return new Code("ERROR", 15);
+                }
             } else {
                 Log.e(LOGTAG, "Stored is null");
-                return new Code("ERROR", 15);
-            }
-            if (token == null){
-                Log.e(LOGTAG, "Token is null");
                 return new Code("ERROR", 15);
             }
             Key key = mKeyStore.getKey(uuid, null);


### PR DESCRIPTION
Added check for null values in stored and token, if null will return "ERROR" instead of an OTP token. Not entirely sure if I've handled this in the ideal way but it doesn't crash anymore if either value is null.