### PR TITLE
Align TOTP Timing Windows

### DIFF
--- a/mobile/src/main/java/org/fedorahosted/freeotp/Token.java
+++ b/mobile/src/main/java/org/fedorahosted/freeotp/Token.java
@@ -367,7 +367,12 @@ public class Token {
         code |= (digest[off + 2] & 0xff) << 0x08;
         code |= (digest[off + 3] & 0xff);
 
-        return Code.Factory.fromIssuer(mIssuer).makeCode(code, mDigits, getPeriod());
+        Code.Factory factory = Code.Factory.fromIssuer(mIssuer);
+        if (mType == Type.TOTP) {
+            return factory.makeTotpCode(code, mDigits, getPeriod());
+        } else {
+            return factory.makeHotpCode(code, mDigits, getPeriod());
+        }
     }
 
     public void setIssuer(String issuer) {

--- a/mobile/src/main/java/org/fedorahosted/freeotp/main/ViewHolder.java
+++ b/mobile/src/main/java/org/fedorahosted/freeotp/main/ViewHolder.java
@@ -156,14 +156,8 @@ class ViewHolder extends RecyclerView.ViewHolder {
 
         mCountdown.cancel();
         mCode.setText(text);
-        Long timeLeft;
-        if (type == Token.Type.HOTP) {
-            timeLeft = code.timeLeft();
-            mCountdown.setDuration(timeLeft);
-        } else {
-            timeLeft = code.timeRemaining() * 1000;
-            mCountdown.setDuration(timeLeft);
-        }
+        long timeLeft = code.timeLeft();
+        mCountdown.setDuration(timeLeft);
 
         mHandler.removeCallbacksAndMessages(null);
         mHandler.postDelayed(() -> fadeOut(), timeLeft);


### PR DESCRIPTION
Synchronize TOTP progress bars

I observed that the progress bars, of TOTP codes, were not synchronized very well (weirdly racing, slow, out-of-sync, etc).  This PR aims to address these kinds of issues.
 
Expectations:
* All TOTP tokens should reach their respective "zero" at the same time.  
  * How long each token is valid is based solely on it's configuration and should be accurately represented by its progress bar
      * A token that is 15 seconds into a 30-second window, should start at 50% and count down for 15 seconds
      * A token that is 15 seconds into a 60-second window, should start at 75% and count down for 45 seconds
      * ... and so on

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED