### PR TITLE
Restore password dialog improvements

### DIFF
--- a/mobile/src/main/java/org/fedorahosted/freeotp/main/RestoreCancelDialogFragment.java
+++ b/mobile/src/main/java/org/fedorahosted/freeotp/main/RestoreCancelDialogFragment.java
@@ -1,0 +1,89 @@
+/*
+ * FreeOTP
+ *
+ * Authors: Brad Williams <brawilli@redhat.com>
+ *
+ * Copyright (C) 2026  Brad Williams, Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fedorahosted.freeotp.main;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.DialogFragment;
+
+import org.fedorahosted.freeotp.R;
+
+public class RestoreCancelDialogFragment extends DialogFragment implements View.OnClickListener {
+    private TextView mGoBackButton;
+    private TextView mProceedButton;
+    private RestoreCancelDialogListener mListener;
+
+    public interface RestoreCancelDialogListener {
+        void onGoBack();
+        void onProceed();
+    }
+
+    static RestoreCancelDialogFragment newInstance() {
+        return new RestoreCancelDialogFragment();
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setCancelable(false);
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+        View v = inflater.inflate(R.layout.fragment_restore_cancel, container, false);
+
+        mGoBackButton = v.findViewById(R.id.restore_cancel_go_back_button);
+        mProceedButton = v.findViewById(R.id.restore_cancel_proceed_button);
+
+        mGoBackButton.setOnClickListener(this);
+        mProceedButton.setOnClickListener(this);
+
+        return v;
+    }
+
+    public void setListener(RestoreCancelDialogListener listener) {
+        mListener = listener;
+    }
+
+    @Override
+    public void onClick(View v) {
+        int id = v.getId();
+        if (id == R.id.restore_cancel_go_back_button) {
+            if (mListener != null) {
+                mListener.onGoBack();
+            }
+            dismiss();
+        } else if (id == R.id.restore_cancel_proceed_button) {
+            if (mListener != null) {
+                mListener.onProceed();
+            }
+            dismiss();
+        }
+    }
+}

--- a/mobile/src/main/java/org/fedorahosted/freeotp/main/RestoreDialogFragment.java
+++ b/mobile/src/main/java/org/fedorahosted/freeotp/main/RestoreDialogFragment.java
@@ -1,0 +1,152 @@
+/*
+ * FreeOTP
+ *
+ * Authors: Brad Williams <brawilli@redhat.com>
+ *
+ * Copyright (C) 2026  Brad Williams, Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fedorahosted.freeotp.main;
+
+import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.view.KeyEvent;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.inputmethod.EditorInfo;
+import android.widget.Button;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.DialogFragment;
+
+import com.google.android.material.textfield.TextInputEditText;
+import com.google.android.material.textfield.TextInputLayout;
+
+import org.fedorahosted.freeotp.R;
+
+public class RestoreDialogFragment extends DialogFragment implements View.OnClickListener {
+    private TextInputEditText mPasswordInput;
+    private TextInputLayout mPasswordLayout;
+    private Button mOkButton;
+    private Button mCancelButton;
+    private RestoreDialogListener mListener;
+
+    public interface RestoreDialogListener {
+        void onRestorePassword(String password);
+        void onRestoreCancel();
+    }
+
+    static RestoreDialogFragment newInstance() {
+        return new RestoreDialogFragment();
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setCancelable(false);
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+        View v = inflater.inflate(R.layout.fragment_restore, container, false);
+
+        mPasswordInput = v.findViewById(R.id.restore_password_input);
+        mPasswordLayout = v.findViewById(R.id.restore_password_layout);
+        mOkButton = v.findViewById(R.id.restore_ok_button);
+        mCancelButton = v.findViewById(R.id.restore_cancel_button);
+
+        mOkButton.setOnClickListener(this);
+        mCancelButton.setOnClickListener(this);
+
+        // Clear error when user starts typing
+        mPasswordInput.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                if (mPasswordLayout.getError() != null) {
+                    mPasswordLayout.setError(null);
+                }
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {}
+        });
+
+        // Handle Enter/Go key press
+        mPasswordInput.setOnEditorActionListener(new TextView.OnEditorActionListener() {
+            @Override
+            public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
+                if (actionId == EditorInfo.IME_ACTION_GO ||
+                    (event != null && event.getKeyCode() == KeyEvent.KEYCODE_ENTER && event.getAction() == KeyEvent.ACTION_DOWN)) {
+                    mOkButton.performClick();
+                    return true;
+                }
+                return false;
+            }
+        });
+
+        return v;
+    }
+
+    public void setListener(RestoreDialogListener listener) {
+        mListener = listener;
+    }
+
+    @Override
+    public void onClick(View v) {
+        int id = v.getId();
+        if (id == R.id.restore_ok_button) {
+            if (mPasswordInput != null && mListener != null) {
+                String password = mPasswordInput.getText().toString();
+
+                // Validate password is not empty
+                if (password.isEmpty()) {
+                    mPasswordLayout.setError(getString(R.string.main_restore_password_required));
+                    return;
+                }
+
+                mListener.onRestorePassword(password);
+            }
+        } else if (id == R.id.restore_cancel_button) {
+            if (mListener != null) {
+                mListener.onRestoreCancel();
+            }
+        }
+    }
+
+    public void clearPassword() {
+        if (mPasswordInput != null) {
+            mPasswordInput.setText("");
+        }
+        if (mPasswordLayout != null) {
+            mPasswordLayout.setError(null);
+        }
+    }
+
+    public void showBadPasswordError() {
+        if (mPasswordLayout != null) {
+            mPasswordLayout.setError(getString(R.string.main_restore_bad_password));
+            mPasswordInput.requestFocus();
+        }
+    }
+}

--- a/mobile/src/main/res/layout/fragment_restore.xml
+++ b/mobile/src/main/res/layout/fragment_restore.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="24dp">
+
+    <TextView
+        android:id="@+id/restore_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/main_restore_title"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        android:paddingBottom="16dp" />
+
+    <TextView
+        android:id="@+id/restore_message"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/main_restore_message"
+        android:paddingBottom="16dp" />
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/restore_password_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/password"
+        app:passwordToggleEnabled="true"
+        app:errorEnabled="true"
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/restore_password_input"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="textPassword"
+            android:typeface="serif"
+            android:minHeight="48dp"
+            android:imeOptions="actionGo" />
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="end"
+        android:paddingTop="16dp">
+
+        <Button
+            android:id="@+id/restore_cancel_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/cancel"
+            android:layout_marginEnd="8dp"
+            style="?android:attr/buttonBarButtonStyle" />
+
+        <Button
+            android:id="@+id/restore_ok_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/ok"
+            style="?android:attr/buttonBarButtonStyle" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/mobile/src/main/res/layout/fragment_restore_cancel.xml
+++ b/mobile/src/main/res/layout/fragment_restore_cancel.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="24dp">
+
+    <TextView
+        android:id="@+id/restore_cancel_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/main_restore_cancel_title"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        android:paddingBottom="16dp" />
+
+    <TextView
+        android:id="@+id/restore_cancel_message"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/main_restore_cancel_message"
+        android:paddingBottom="24dp" />
+
+    <TextView
+        android:id="@+id/restore_cancel_proceed_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end"
+        android:text="@string/main_restore_proceed"
+        android:textColor="?android:attr/textColorLink"
+        android:textSize="16sp"
+        android:paddingTop="12dp"
+        android:paddingBottom="12dp"
+        android:clickable="true"
+        android:focusable="true"
+        android:background="?android:attr/selectableItemBackground" />
+
+    <TextView
+        android:id="@+id/restore_cancel_go_back_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end"
+        android:text="@string/main_restore_go_back"
+        android:textColor="?android:attr/textColorLink"
+        android:textSize="16sp"
+        android:paddingTop="12dp"
+        android:paddingBottom="12dp"
+        android:clickable="true"
+        android:focusable="true"
+        android:background="?android:attr/selectableItemBackground" />
+
+</LinearLayout>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -68,6 +68,7 @@
     <string name="main_restore_title">Restore from backup</string>
     <string name="main_restore_message">Please enter backup password\n\nUpon successful restore, this password used to restore will overwrite any previously setup backup password</string>
     <string name="main_restore_bad_password">Invalid password</string>
+    <string name="main_restore_password_required">Password is required</string>
     <string name="main_restore_cancel_title">Cancel Restore?</string>
     <string name="main_restore_cancel_message">You will lose all previously backed up tokens!</string>
     <string name="main_restore_proceed">Proceed without Restoring</string>


### PR DESCRIPTION
This PR converts the restore password AlertDialogs into modern, custom DialogFragments with enhanced UX capabilities.

/fixes #472

Initial Restore dialog - Light
<img width="540" height="1200" alt="restore_password_light" src="https://github.com/user-attachments/assets/c6558d32-407c-413a-97f2-e7cde853adaf" /> 

Initial Restore dialog - Dark
<img width="540" height="1200" alt="restore_password_dark" src="https://github.com/user-attachments/assets/980519fa-0cb0-412c-8edc-fc6f2c20356a" />

Password required - Light
<img width="540" height="1200" alt="password_required_light" src="https://github.com/user-attachments/assets/f59ca463-2207-4fa2-bbcd-38949bc43575" />

Password required - Dark
<img width="540" height="1200" alt="password_required_dark" src="https://github.com/user-attachments/assets/75c113f1-58e3-438e-b69f-3c6336c4c031" />

Password invalid - Light
<img width="540" height="1200" alt="password_invalid_light" src="https://github.com/user-attachments/assets/f714d1bb-db38-40b9-a39b-1d39efcc830d" />

Password invalid - Dark
<img width="540" height="1200" alt="password_invalid_dark" src="https://github.com/user-attachments/assets/3b0730aa-21e4-474a-9481-01399e5804ee" />

Restore Cancel - Light
<img width="540" height="1200" alt="restore_cancel_light" src="https://github.com/user-attachments/assets/a81b1b32-5ebe-443a-97ce-96bbb71da374" />

Restore Cancel - Dark
<img width="540" height="1200" alt="restore_cancel_dark" src="https://github.com/user-attachments/assets/f6dff178-fdfc-43dc-ac38-35360b73815b" />
