### PR TITLE
Switching Dark Mode's default "purple" to a desaturated value

### DIFF
--- a/mobile/src/main/res/values-night/themes.xml
+++ b/mobile/src/main/res/values-night/themes.xml
@@ -2,8 +2,8 @@
 <resources>
     <!-- Overrides for dark mode -->
     <style name="FreeOTP.Purple">
-        <item name="colorPrimary">@color/purple_500</item>
-        <item name="colorSecondary">@color/purple_500</item>
+        <item name="colorPrimary">@color/purple_200</item>
+        <item name="colorSecondary">@color/purple_200</item>
         <item name="colorPrimaryVariant">@color/freeotp_grey_dark_primary</item>
         <item name="colorPrimaryDark">@color/dark_grey</item>
         <item name="buttoncolor">@drawable/buttoncolor</item>


### PR DESCRIPTION
Addressing comment from PR #482 regarding "Desaturated colors for accessibility".

According to: https://m2.material.io/design/color/dark-theme.html#ui-application, the 200 value of purple is an acceptable color for the existing purple that been used.

Main screen - original
<img width="540" height="1200" alt="main_screen_orig" src="https://github.com/user-attachments/assets/7e13299c-3eda-4e07-a7c5-eaad74fb368e" />

Main screen - desaturated
<img width="540" height="1200" alt="main_screen_desaturated" src="https://github.com/user-attachments/assets/b5e68339-0af1-41d2-8874-553d9d0fdfa5" />

Add token screen - original
<img width="540" height="1200" alt="add_token_orig" src="https://github.com/user-attachments/assets/8b48731e-bb76-4479-9814-7e7abf42bfff" />

Add token screen - desaturated
<img width="540" height="1200" alt="add_token_desaturated" src="https://github.com/user-attachments/assets/205723f4-e429-4de9-a280-6218130e96e5" />

Restore password screen - original
<img width="540" height="1200" alt="restore_password_orig" src="https://github.com/user-attachments/assets/b95efd97-0050-46f2-be8d-557f0a110e99" />

Restore password screen - desaturated
<img width="540" height="1200" alt="restore_password_desaturated" src="https://github.com/user-attachments/assets/d67c6802-4cec-4ad1-a34a-aa06c4bacc76" />

Restore password cancel screen - original
<img width="540" height="1200" alt="cancel_orig" src="https://github.com/user-attachments/assets/6a73ba57-6d3e-4092-b709-8bedd1e02154" />

Restore password cancel screen - desaturated
<img width="540" height="1200" alt="cancel_desaturated" src="https://github.com/user-attachments/assets/8cf0c42b-a9e0-46a6-8c00-45fca15866fb" />
