### PR TITLE
Jelling: Switch to BR/EDR on connectGatt

### DIFF
--- a/mobile/src/main/java/org/fedorahosted/freeotp/main/share/Jelling.java
+++ b/mobile/src/main/java/org/fedorahosted/freeotp/main/share/Jelling.java
@@ -257,7 +257,7 @@ class Jelling extends Discoverable {
                 mDeviceItemMap.put(dev, item);
                 appear(item, (token, shareCallback) -> {
                     GattCallback gc = new GattCallback(token, shareCallback);
-                    mBluetoothGatt = dev.connectGatt(mContext, false, gc);
+                    mBluetoothGatt = dev.connectGatt(mContext, false, gc, BluetoothDevice.TRANSPORT_BREDR);
                 });
             }
 


### PR DESCRIPTION
With LE, Android’s LE Privacy may use a randomized address, causing
Jelling/BlueZ to reject writes.

Force TRANSPORT_BREDR to ensure a stable bonded identity and allow
secure writes to succeed.
