### PR TITLE
Jelling: Gracefully handle server restart

### DIFF
--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -43,6 +43,7 @@
     <string name="share_jelling_scan_for">Scan for…</string>
     <string name="share_jelling_scanning_for">Scanning for…</string>
     <string name="share_jelling_bluetooth_devices">Bluetooth Devices</string>
+    <string name="share_jelling_stale_handles">Connection failed, try again.</string>
     <string name="share_clipboard_copy_to">Copy to…</string>
     <string name="share_clipboard_clipboard">Clipboard</string>
 


### PR DESCRIPTION
Turns out PR #489 didn’t actually fix the issue. My bad.

> 2 Hardest problems in programming:
> 1. Naming things (Jelling? seriously?)
> 2. Cache invalidation (Yeah, I'm laughing at myself)
> 3. Off-by-one errors (this joke)

This issue was caused by BLE handle invalidation, as BlueZ resets the HCI after waking up from sleep. This causes all writes after a suspend/hibernate cycle to fail.

* Android caches BLE service handles if the device is paired, but it only invalidates that cache if `ServiceChanged` is fired.
* BlueZ almost never triggers that event (only on `RegisterApplication`/`UnregisterApplication`), and Android misses it when not connected.

Spent way too much time in BlueZ source, Wireshark dumps, Android BT API docs
Even GPT/Gemini... yeah, those guys started hallucinating, and finally,
a 5-year-old StackOverflow thread... thankfully it wasn't by DenverCoder9.

I'll have a good sleep, then create PR for jelling-linux tomorrow...