### PR TITLE
Steam tokens should be reversed

### DIFF
--- a/mobile/src/main/java/org/fedorahosted/freeotp/Code.java
+++ b/mobile/src/main/java/org/fedorahosted/freeotp/Code.java
@@ -55,22 +55,25 @@ public class Code {
             return (int) Math.floor(Math.log(RFC_MAX) / Math.log(mAlphabet.length));
         }
 
-        Code makeHotpCode(int code, @Nullable Integer digits, int period) {
-            return makeCode(code, digits, period, false);
+        Code makeHotpCode(int code, @Nullable Integer digits, int period, boolean reverse) {
+            return makeCode(code, digits, period, reverse, false);
         }
 
-        Code makeTotpCode(int code, @Nullable Integer digits, int period) {
-            return makeCode(code, digits, period, true);
+        Code makeTotpCode(int code, @Nullable Integer digits, int period, boolean reverse) {
+            return makeCode(code, digits, period, reverse, true);
         }
 
-        private Code makeCode(int code, @Nullable Integer digits, int period, boolean alignToWindow) {
+        private Code makeCode(int code, @Nullable Integer digits, int period, boolean reverse, boolean alignToWindow) {
             if (digits == null)
                 digits = mDigits;
 
             char[] buffer = new char[digits];
 
             for (int i = 0; i < digits; i++) {
-                buffer[digits - i - 1] = mAlphabet[code % mAlphabet.length];
+                if (reverse)
+                    buffer[i] = mAlphabet[code % mAlphabet.length];
+                else
+                    buffer[digits - i - 1] = mAlphabet[code % mAlphabet.length];
                 code /= mAlphabet.length;
             }
 

--- a/mobile/src/main/java/org/fedorahosted/freeotp/Token.java
+++ b/mobile/src/main/java/org/fedorahosted/freeotp/Token.java
@@ -36,6 +36,7 @@ import java.security.InvalidKeyException;
 import java.security.Key;
 import java.security.NoSuchAlgorithmException;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
@@ -370,11 +371,14 @@ public class Token {
         code |= (digest[off + 2] & 0xff) << 0x08;
         code |= (digest[off + 3] & 0xff);
 
+        // Steam reverses OTP code.
+        boolean reverse = Objects.equals(mIssuer, "Steam");
+
         Code.Factory factory = Code.Factory.fromIssuer(mIssuer);
         if (mType == Type.TOTP) {
-            return factory.makeTotpCode(code, mDigits, getPeriod());
+            return factory.makeTotpCode(code, mDigits, getPeriod(), reverse);
         } else {
-            return factory.makeHotpCode(code, mDigits, getPeriod());
+            return factory.makeHotpCode(code, mDigits, getPeriod(), reverse);
         }
     }
 


### PR DESCRIPTION
Lost in the Material Design and Keystore rewrite.

Was referenced in https://github.com/freeotp/freeotp-android/issues/314 but perhaps missed due to the similar but separate RTL issue. Don't have a android build system to test but should compile and work.