### PR TITLE
Updated copyright. Fixes: #497

### DIFF
--- a/mobile/src/main/res/values-co/strings.xml
+++ b/mobile/src/main/res/values-co/strings.xml
@@ -64,7 +64,7 @@ Information about Corsican localization:
 
 	<!-- Strings for the various dialogs. -->
 	<string name="main_about_title">FreeOTP versione %1$s (%2$d)</string>
-	<string name="main_about_message">© 2013–2023 - Red Hat, Inc., et al.&lt;br/&gt;&lt;br/&gt;FreeOTP hè publicatu sottu a licenza &lt;a href=&quot;https://www.apache.org/licenses/LICENSE-2.0.html&quot;&gt;Apache 2.0&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Per sapene di più, fighjate u nostru &lt;a href=&quot;https://freeotp.github.io&quot;&gt;situ web&lt;/a&gt;.</string>
+	<string name="main_about_message">Copyright Red Hat&lt;br/&gt;&lt;br/&gt;FreeOTP hè publicatu sottu a licenza &lt;a href=&quot;https://www.apache.org/licenses/LICENSE-2.0.html&quot;&gt;Apache 2.0&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Per sapene di più, fighjate u nostru &lt;a href=&quot;https://freeotp.github.io&quot;&gt;situ web&lt;/a&gt;.</string>
 	<string name="main_welcome">Benvenuta in FreeOTP&#x00a0;!\n\nAghjunghjite un gettone per principià.</string>
 	<string name="main_deletion_title">Squassà i gettoni selezziunati&#x00a0;?</string>
 	<string name="main_deletion_message">A squassatura d’un gettone ùn u disattiveghja micca nant’à u servitore. S’è vo cuntinuate, u vostru contu puderia esse bluccatu. A squassatura d’un gettone ùn pò micca esse disfata.</string>

--- a/mobile/src/main/res/values-de/strings.xml
+++ b/mobile/src/main/res/values-de/strings.xml
@@ -49,7 +49,7 @@
 
     <!-- Strings for the various dialogs. -->
     <string name="main_about_title">FreeOTP Version %1$s (%2$d)</string>
-    <string name="main_about_message">© 2013–2023 - Red Hat, Inc., et al.&lt;br/&gt;&lt;br/&gt;FreeOTP ist lizensiert unter &lt;a href=&quot;https://www.apache.org/licenses/LICENSE-2.0.html&quot;&gt;Apache 2.0&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Weitere Informationen finden Sie auf unserer &lt;a href=&quot;https://freeotp.github.io&quot;&gt;Website&lt;/a&gt;.</string>
+    <string name="main_about_message">Copyright Red Hat&lt;br/&gt;&lt;br/&gt;FreeOTP ist lizensiert unter &lt;a href=&quot;https://www.apache.org/licenses/LICENSE-2.0.html&quot;&gt;Apache 2.0&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Weitere Informationen finden Sie auf unserer &lt;a href=&quot;https://freeotp.github.io&quot;&gt;Website&lt;/a&gt;.</string>
     <string name="main_welcome">Willkommen bei FreeOTP!\n\nFügen Sie ein Token hinzu, um loszulegen.</string>
     <string name="main_deletion_title">Ausgewählte Token löschen?</string>
     <string name="main_deletion_message">Beim Löschen eines Tokens wird dieser nicht auf dem Server deaktiviert. Wenn Sie fortfahren, werden Sie möglicherweise von Ihrem Konto ausgesperrt. Die Löschung eines Tokens kann nicht rückgängig gemacht werden.</string>

--- a/mobile/src/main/res/values-eu/strings.xml
+++ b/mobile/src/main/res/values-eu/strings.xml
@@ -50,7 +50,7 @@
 
     <!-- Strings for the various dialogs. -->
     <string name="main_about_title">FreeOTP %1$s (%2$d) bertsioa</string>
-    <string name="main_about_message">© 2013–2023 - Red Hat, Inc., et al.&lt;br/&gt;&lt;br/&gt;FreeOTP-k &lt;a href=&quot;https://www.apache.org/licenses/LICENSE-2.0.html&quot;&gt;Apache 2.0&lt;/a&gt; lizentzia du.&lt;br/&gt;&lt;br/&gt;Informazio gehiago &lt;a href=&quot;https://freeotp.github.io&quot;&gt;gure webgunean&lt;/a&gt;.</string>
+    <string name="main_about_message">Copyright Red Hat&lt;br/&gt;&lt;br/&gt;FreeOTP-k &lt;a href=&quot;https://www.apache.org/licenses/LICENSE-2.0.html&quot;&gt;Apache 2.0&lt;/a&gt; lizentzia du.&lt;br/&gt;&lt;br/&gt;Informazio gehiago &lt;a href=&quot;https://freeotp.github.io&quot;&gt;gure webgunean&lt;/a&gt;.</string>
     <string name="main_welcome">Ongi etorri FreeOTP-ra!\n\nGehitu token bat hasteko.</string>
     <string name="main_deletion_title">Hautatutako tokenak ezabatu?</string>
     <string name="main_deletion_message">Token bat ezabatzeak ez du desgaitzen zerbitzarian. Jarraitzen baduzu, kontua blokeatuta geratu daiteke. Token bat ezabatzea ezin da desegin.</string>

--- a/mobile/src/main/res/values-fr/strings.xml
+++ b/mobile/src/main/res/values-fr/strings.xml
@@ -57,7 +57,7 @@
 
     <!-- Strings for the various dialogs. -->
     <string name="main_about_title">FreeOTP version %1$s (%2$d)</string>
-    <string name="main_about_message">© 2013–2023 - Red Hat, Inc., et al.&lt;br/&gt;&lt;br/&gt;FreeOTP est publié sous licence &lt;a href=&quot;https://www.apache.org/licenses/LICENSE-2.0.html&quot;&gt;Apache 2.0&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Pour plus d\'information, visitez notre &lt;a href=&quot;https://freeotp.github.io&quot;&gt;site web&lt;/a&gt;.</string>
+    <string name="main_about_message">Copyright Red Hat&lt;br/&gt;&lt;br/&gt;FreeOTP est publié sous licence &lt;a href=&quot;https://www.apache.org/licenses/LICENSE-2.0.html&quot;&gt;Apache 2.0&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Pour plus d\'information, visitez notre &lt;a href=&quot;https://freeotp.github.io&quot;&gt;site web&lt;/a&gt;.</string>
     <string name="main_welcome">Bienvenue dans FreeOTP\u00A0!\n\nAjouter un jeton pour commencer.</string>
     <string name="main_deletion_title">Supprimer les jetons sélectionnés\u00A0?</string>
     <string name="main_deletion_message">Supprimer un jeton ne le désactive pas sur le serveur. Si vous continuez, vous pourriez être exclu de l\'accès à votre compte. Un jeton supprimé ne peut être restauré.</string>

--- a/mobile/src/main/res/values-nb/strings.xml
+++ b/mobile/src/main/res/values-nb/strings.xml
@@ -30,7 +30,7 @@
 
     <!-- Strings for the various dialogs. -->
     <string name="main_about_title">FreeOTP Versjon %1$s (%2$d)</string>
-    <string name="main_about_message">© 2013–2023 - Red Hat, Inc., og andre.&lt;br/&gt;&lt;br/&gt;FreeOTP er lisensiert under &lt;a href=&quot;https://www.apache.org/licenses/LICENSE-2.0.html&quot;&gt;Apache 2.0&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;For mer informasjon, se vår &lt;a href=&quot;https://freeotp.github.io&quot;&gt;nettside&lt;/a&gt;.</string>
+    <string name="main_about_message">Copyright Red Hat&lt;br/&gt;&lt;br/&gt;FreeOTP er lisensiert under &lt;a href=&quot;https://www.apache.org/licenses/LICENSE-2.0.html&quot;&gt;Apache 2.0&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;For mer informasjon, se vår &lt;a href=&quot;https://freeotp.github.io&quot;&gt;nettside&lt;/a&gt;.</string>
     <string name="main_welcome">Velkommen til FreeOTP!\n\nLegg til en nøkkel for å komme i gang.</string>
     <string name="main_deletion_title">Slett valgte nøkler?</string>
     <string name="main_deletion_message">Sletting av en nøkkel deaktiverer den ikke på tjenesten. Hvis du fortsetter, kan du bli utestengt fra kontoen din. Sletting av en nøkkel kan ikke angres.</string>

--- a/mobile/src/main/res/values-nl/strings.xml
+++ b/mobile/src/main/res/values-nl/strings.xml
@@ -31,7 +31,7 @@
 
     <!-- Strings for the various dialogs. -->
     <string name="main_about_title">FreeOTP Version %1$s (%2$d)</string>
-    <string name="main_about_message">© 2013–2023 - Red Hat, Inc., et al.&lt;br/&gt;&lt;br/&gt;FreeOTP is gelicenseerd onder &lt;a href=&quot;https://www.apache.org/licenses/LICENSE-2.0.html&quot;&gt;Apache 2.0&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Voor meer informatie, zie onze &lt;a href=&quot;https://freeotp.github.io&quot;&gt;website&lt;/a&gt;.</string>
+    <string name="main_about_message">Copyright Red Hat&lt;br/&gt;&lt;br/&gt;FreeOTP is gelicenseerd onder &lt;a href=&quot;https://www.apache.org/licenses/LICENSE-2.0.html&quot;&gt;Apache 2.0&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Voor meer informatie, zie onze &lt;a href=&quot;https://freeotp.github.io&quot;&gt;website&lt;/a&gt;.</string>
     <string name="main_welcome">Welkom bij FreeOTP!\n\nVoeg een token toe om te beginnen.</string>
     <string name="main_deletion_title">Geselecteerde tokens verwijderen?</string>
     <string name="main_deletion_message">Het verwijderen van een token schakelt deze niet uit op de server. Als u doorgaat, heeft u mogelijk geen toegang meer tot uw account. Het verwijderen van een token kan niet ongedaan worden gemaakt.</string>

--- a/mobile/src/main/res/values-pt-rPT/strings.xml
+++ b/mobile/src/main/res/values-pt-rPT/strings.xml
@@ -30,7 +30,7 @@
     
     <!-- Strings for the various dialogs. -->
     <string name="main_about_title">FreeOTP Versão %1$s (%2$d)</string>
-    <string name="main_about_message">© 2013–2023 - Red Hat, Inc., et al.&lt;br/&gt;&lt;br/&gt;FreeOTP é licenciado sob &lt;a href=&quot;https://www.apache.org/licenses/LICENSE-2.0.html&quot;&gt;Apache 2.0&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Para mais informações, veja nosso &lt;a href=&quot;https://freeotp.github.io&quot;&gt;site&lt;/a&gt;.</string>
+    <string name="main_about_message">Copyright Red Hat&lt;br/&gt;&lt;br/&gt;FreeOTP é licenciado sob &lt;a href=&quot;https://www.apache.org/licenses/LICENSE-2.0.html&quot;&gt;Apache 2.0&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Para mais informações, veja nosso &lt;a href=&quot;https://freeotp.github.io&quot;&gt;site&lt;/a&gt;.</string>
     <string name="main_welcome">Bem-vindo ao FreeOTP!\n\nAdicione um token para começar.</string>
     <string name="main_deletion_title">Excluir tokens selecionados?</string>
     <string name="main_deletion_message">A exclusão de um token não o desativa no servidor. Se você continuar, sua conta poderá ser bloqueada. A exclusão de um token não pode ser desfeita.</string>

--- a/mobile/src/main/res/values-sv/strings.xml
+++ b/mobile/src/main/res/values-sv/strings.xml
@@ -50,7 +50,7 @@
 
     <!-- Strings for the various dialogs. -->
     <string name="main_about_title">FreeOTP Version %1$s (%2$d)</string>
-    <string name="main_about_message">© 2013–2023 - Red Hat, Inc., et al.&lt;br/&gt;&lt;br/&gt;FreeOTP är licensierat under &lt;a href=&quot;https://www.apache.org/licenses/LICENSE-2.0.html&quot;&gt;Apache 2.0&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;För mer information, besök vår &lt;a href=&quot;https://freeotp.github.io&quot;&gt;webbplats&lt;/a&gt;.</string>
+    <string name="main_about_message">Copyright Red Hat&lt;br/&gt;&lt;br/&gt;FreeOTP är licensierat under &lt;a href=&quot;https://www.apache.org/licenses/LICENSE-2.0.html&quot;&gt;Apache 2.0&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;För mer information, besök vår &lt;a href=&quot;https://freeotp.github.io&quot;&gt;webbplats&lt;/a&gt;.</string>
     <string name="main_welcome">Välkommen till FreeOTP!\n\nLägg till en token för att komma igång.</string>
     <string name="main_deletion_title">Radera markerade tokens?</string>
     <string name="main_deletion_message">Att radera en token inaktiverar inte den på servern. Om du fortsätter kan du bli utelåst från ditt konto. Radering av en token kan inte ångras.</string>

--- a/mobile/src/main/res/values-zh-rTW/strings.xml
+++ b/mobile/src/main/res/values-zh-rTW/strings.xml
@@ -47,7 +47,7 @@
     <string name="error_camera_open">開啟相機時發生錯誤！</string>
     <!-- Strings for the various dialogs. -->
     <string name="main_about_title">FreeOTP 版本 %1$s (%2$d)</string>
-    <string name="main_about_message">© 2013–2023 - Red Hat, Inc., et al.&lt;br/&gt;&lt;br/&gt;FreeOTP 採用 &lt;a href=https://www.apache.org/licenses/LICENSE-2.0.html&gt;Apache 2.0&lt;/a&gt; 授權。&lt;br/&gt;&lt;br/&gt;如需更多資訊，請參閱我們的 &lt;a href=https://freeotp.github.io&gt;網站&lt;/a&gt;。</string>
+    <string name="main_about_message">Copyright Red Hat&lt;br/&gt;&lt;br/&gt;FreeOTP 採用 &lt;a href=https://www.apache.org/licenses/LICENSE-2.0.html&gt;Apache 2.0&lt;/a&gt; 授權。&lt;br/&gt;&lt;br/&gt;如需更多資訊，請參閱我們的 &lt;a href=https://freeotp.github.io&gt;網站&lt;/a&gt;。</string>
     <string name="main_welcome">歡迎使用 FreeOTP！
 \n
 \n請新增一組動態密碼後開始使用。</string>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -57,7 +57,7 @@
 
     <!-- Strings for the various dialogs. -->
     <string name="main_about_title">FreeOTP Version %1$s (%2$d)</string>
-    <string name="main_about_message">© 2013–2023 - Red Hat, Inc., et al.&lt;br/&gt;&lt;br/&gt;FreeOTP is licensed under &lt;a href=&quot;https://www.apache.org/licenses/LICENSE-2.0.html&quot;&gt;Apache 2.0&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;For more information, see our &lt;a href=&quot;https://freeotp.github.io&quot;&gt;website&lt;/a&gt;.</string>
+    <string name="main_about_message">Copyright Red Hat&lt;br/&gt;&lt;br/&gt;FreeOTP is licensed under &lt;a href=&quot;https://www.apache.org/licenses/LICENSE-2.0.html&quot;&gt;Apache 2.0&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;For more information, see our &lt;a href=&quot;https://freeotp.github.io&quot;&gt;website&lt;/a&gt;.</string>
     <string name="main_welcome">Welcome to FreeOTP!\n\nAdd a token to get started.</string>
     <string name="main_deletion_title">Delete selected tokens?</string>
     <string name="main_deletion_message">Deleting a token does not disable it on the server. If you continue, you may be locked out of your account. Deleting a token cannot be undone.</string>


### PR DESCRIPTION
Updated copyright in About according to Red Hat copyright notice guidelines.

Updated strings.xml and for translations:
- values-co
- values-de
- values-eu
- values-fr
- values-nb
- values-nl
- values-pt-rPT
- values-sv
- values-zh-rTW