### PR TITLE
Steam default to 5 digit codes

### DIFF
--- a/mobile/src/main/java/org/fedorahosted/freeotp/Token.java
+++ b/mobile/src/main/java/org/fedorahosted/freeotp/Token.java
@@ -279,7 +279,10 @@ public class Token {
 
         try {
             String s = uri.getQueryParameter("digits");
-            mDigits = s == null ? null : Integer.parseInt(s);
+            if (Objects.equals(mIssuer, "Steam"))
+                mDigits = 5;
+            else
+                mDigits = s == null ? null : Integer.parseInt(s);
             if (mDigits != null && mDigits < 0)
                 throw new InvalidDigitsException();
         } catch (NumberFormatException x) {


### PR DESCRIPTION
Force to 5 when manually entering Steam tokens.

Note when using a QR code generated from Steams otpauth:// it does not have a digits param and so mDigits is left undefined and calculated to 5 by getDigitsMin().

Replaces https://github.com/freeotp/freeotp-android/pull/252. Let Gradle run to check.